### PR TITLE
Refactor Markdown style of Readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ file](LICENSE-CC-BY) and rename it to `LICENSE`.
 ```markdown
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-This work is licensed under a [Creative Commons Attribution 4.0 International License][cc-by].
+This work is licensed under a
+[Creative Commons Attribution 4.0 International License][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 
@@ -66,7 +67,8 @@ file](LICENSE-CC-BY-SA) and rename it to `LICENSE`.
 ```markdown
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
+This work is licensed under a
+[Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Deutsch](https://img.shields.io/badge/translation-DE-red)](de/)
 
----
-
 In this repo you can find easy ways for applying Creative Commons Licenses on Github repositories through Markdown language.
 
 > **WARNING:**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Deutsch](https://img.shields.io/badge/translation-DE-red)](de/)
 
-In this repo you can find easy ways for applying Creative Commons Licenses on Github repositories through Markdown language.
+In this repo you can find easy ways for applying Creative Commons Licenses on
+Github repositories through Markdown language.
 
 > **WARNING:**
 > You shouldn't use Creative Commons licenses for software.
@@ -10,7 +11,8 @@ In this repo you can find easy ways for applying Creative Commons Licenses on Gi
 > Creative Commons Licenses are ment for intellectual works only.
 
 
-The easiest way for finding the right CC License for your project is the [Creative Commons website](https://creativecommons.org/choose/).
+The easiest way for finding the right CC License for your project is the
+[Creative Commons website](https://creativecommons.org/choose/).
 
 Here we present two types of CC Licenses:
 
@@ -18,15 +20,18 @@ Here we present two types of CC Licenses:
 
 * [Creative Commons Attribution-ShareAlike 4.0 International](#cc-attribution-sharealike-40-international)
 
-More information about licenses, and plain-text formatted licenses texts can be found on https://choosealicense.com/.
+More information about licenses, and plain-text formatted licenses texts can be
+found on https://choosealicense.com/.
 
-If you want to download vectorized version of Creative Commons images and other related stuff, please visit https://creativecommons.org/about/downloads/.
+If you want to download vectorized version of Creative Commons images and other
+related stuff, please visit https://creativecommons.org/about/downloads/.
 
 
 ## CC Attribution 4.0 International
 
-To add a CC BY License to your project, just add the following to your `README.md`.
-You should also copy the corresponding [license text file](LICENSE-CC-BY) and rename it to `LICENSE`.
+To add a CC BY License to your project, just add the following to your
+`README.md`. You should also copy the corresponding [license text
+file](LICENSE-CC-BY) and rename it to `LICENSE`.
 
 ```markdown
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
@@ -42,7 +47,8 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-This work is licensed under a [Creative Commons Attribution 4.0 International License][cc-by].
+This work is licensed under a
+[Creative Commons Attribution 4.0 International License][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 
@@ -53,7 +59,9 @@ This work is licensed under a [Creative Commons Attribution 4.0 International Li
 
 ## CC Attribution-ShareAlike 4.0 International
 
-To add a CC BY-SA License to your project, just add the following to your `README.md`. You should also copy the corresponding [license text file](LICENSE-CC-BY-SA) and rename it to `LICENSE`.
+To add a CC BY-SA License to your project, just add the following to your
+`README.md`. You should also copy the corresponding [license text
+file](LICENSE-CC-BY-SA) and rename it to `LICENSE`.
 
 ```markdown
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
@@ -69,7 +77,8 @@ This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 Inter
 
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
+This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0
+International License][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 

--- a/de/README.md
+++ b/de/README.md
@@ -82,8 +82,8 @@ Diese Arbeit unterliegt den Bestimmungen einer
 
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung
-- Weitergabe unter gleichen Bedingungen 4.0 International-Lizenz][cc-by-sa].
+Diese Arbeit unterliegt den Bestimmungen einer
+[Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International-Lizenz][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 

--- a/de/README.md
+++ b/de/README.md
@@ -1,6 +1,6 @@
 # Creative Commons Licenses für GitHub-Projekte
 
-[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/)
+[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/#)
 
 In diesem Repo lernen Sie einfache Möglichkeiten kennen, um Creative Commons-Lizenzen auf
 Github-Repositories per Markdown-Sprache anzuwenden.

--- a/de/README.md
+++ b/de/README.md
@@ -1,6 +1,6 @@
 # Creative Commons Licenses für GitHub-Projekte
 
-[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/../)
+[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/../../)
 
 In diesem Repo lernen Sie einfache Möglichkeiten kennen, um Creative Commons-Lizenzen auf
 Github-Repositories per Markdown-Sprache anzuwenden.

--- a/de/README.md
+++ b/de/README.md
@@ -39,7 +39,8 @@ Folgende zu Ihrer `README.md` hinzu. Sie sollten auch die entsprechende
 ```markdown
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung 4.0 International-Lizenz][cc-by].
+Diese Arbeit unterliegt den Bestimmungen einer
+[Creative Commons Namensnennung 4.0 International-Lizenz][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 
@@ -69,7 +70,8 @@ Folgende zu Ihrer `README.md` hinzu. Sie sollten auch die entsprechende
 ```markdown
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International-Lizenz][cc-by].
+Diese Arbeit unterliegt den Bestimmungen einer
+[Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International-Lizenz][cc-by].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 

--- a/de/README.md
+++ b/de/README.md
@@ -1,6 +1,6 @@
 # Creative Commons Licenses für GitHub-Projekte
 
-[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/#)
+[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/../)
 
 In diesem Repo lernen Sie einfache Möglichkeiten kennen, um Creative Commons-Lizenzen auf
 Github-Repositories per Markdown-Sprache anzuwenden.

--- a/de/README.md
+++ b/de/README.md
@@ -2,8 +2,8 @@
 
 [![Main](https://img.shields.io/badge/main%20language-EN-blue)](/../../)
 
-In diesem Repo lernen Sie einfache Möglichkeiten kennen, um Creative Commons-Lizenzen auf
-Github-Repositories per Markdown-Sprache anzuwenden.
+In diesem Repo lernen Sie einfache Möglichkeiten kennen, um Creative
+Commons-Lizenzen auf Github-Repositories per Markdown-Sprache anzuwenden.
 
 > **WARNUNG:**
 > Du solltest Creative Commons-Lizenzen nicht für Software benutzen.
@@ -11,22 +11,30 @@ Github-Repositories per Markdown-Sprache anzuwenden.
 > Creative Commons-Lizenzen sind nur für geistige Werke vorgesehen.
 
 
-Der einfachste Weg um die richtige CC-Lizenz für Ihr Projekt zu finden ist die [Creative Commons-Website](https://creativecommons.org/choose/).
+Der einfachste Weg um die richtige CC-Lizenz für Ihr Projekt zu finden ist die
+[Creative Commons-Website](https://creativecommons.org/choose/).
 
 Hier präsentieren wir zwei Typen von CC-Lizenzen:
 
-* [Creative Commons Namensnennung 4.0 International](#cc-namensnennung-40-international) (Creative Commons Attribution 4.0 International)
+* [Creative Commons Namensnennung 4.0 International](#cc-namensnennung-40-international)
+  (Creative Commons Attribution 4.0 International)
 
-* [Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International](#cc-namensnennung---weitergabe-unter-gleichen-bedingungen-40-international) (Creative Commons Attribution-ShareAlike 4.0 International)
+* [Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International](#cc-namensnennung---weitergabe-unter-gleichen-bedingungen-40-international)
+  (Creative Commons Attribution-ShareAlike 4.0 International)
 
-Weitere Information über Lizenzen und in Klartext formatierte Lizenz-Texte können hier gefunden werden: https://choosealicense.com/
+Weitere Information über Lizenzen und in Klartext formatierte Lizenz-Texte
+können hier gefunden werden: https://choosealicense.com/
 
-Wenn Sie eine vektorisierte Version von Creative Commons-Bildern und anderem zugehörigen Kram herunterladen wollen, besuchen Sie bitte https://creativecommons.org/about/downloads/.
+Wenn Sie eine vektorisierte Version von Creative Commons-Bildern und anderem
+zugehörigen Kram herunterladen wollen, besuchen Sie bitte
+https://creativecommons.org/about/downloads/.
 
 
 ## CC Namensnennung 4.0 International
 
-Um eine CC BY-Lizenz zu Ihrem Projekt hinzuzufügen, fügen Sie einfach das Folgende zu Ihrer `README.md` hinzu. Sie sollten auch die entsprechende [Lizenztextdatei](LICENSE-CC-BY) kopieren und sie zu `LICENSE` umbenennen.
+Um eine CC BY-Lizenz zu Ihrem Projekt hinzuzufügen, fügen Sie einfach das
+Folgende zu Ihrer `README.md` hinzu. Sie sollten auch die entsprechende
+[Lizenztextdatei](LICENSE-CC-BY) kopieren und sie zu `LICENSE` umbenennen.
 
 ```markdown
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
@@ -42,7 +50,8 @@ Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung 4
 
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung 4.0 International-Lizenz][cc-by].
+Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung
+4.0 International-Lizenz][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 
@@ -53,7 +62,9 @@ Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung 4
 
 ## CC Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International
 
-Um eine CC BY-SA-Lizenz zu Ihrem Projekt hinzuzufügen, fügen Sie einfach das Folgende zu Ihrer `README.md` hinzu. Sie sollten auch die entsprechende [Lizenztextdatei](LICENSE-CC-BY-SA) kopieren und sie zu `LICENSE` umbenennen.
+Um eine CC BY-SA-Lizenz zu Ihrem Projekt hinzuzufügen, fügen Sie einfach das
+Folgende zu Ihrer `README.md` hinzu. Sie sollten auch die entsprechende
+[Lizenztextdatei](LICENSE-CC-BY-SA) kopieren und sie zu `LICENSE` umbenennen.
 
 ```markdown
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
@@ -69,7 +80,8 @@ Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung -
 
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung - Weitergabe unter gleichen Bedingungen 4.0 International-Lizenz][cc-by-sa].
+Diese Arbeit unterliegt den Bestimmungen einer [Creative Commons Namensnennung
+- Weitergabe unter gleichen Bedingungen 4.0 International-Lizenz][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 

--- a/de/README.md
+++ b/de/README.md
@@ -2,8 +2,6 @@
 
 [![Main](https://img.shields.io/badge/main%20language-EN-blue)](/README.md)
 
----
-
 In diesem Repo lernen Sie einfache Möglichkeiten kennen, um Creative Commons-Lizenzen auf
 Github-Repositories per Markdown-Sprache anzuwenden.
 

--- a/de/README.md
+++ b/de/README.md
@@ -1,6 +1,6 @@
 # Creative Commons Licenses für GitHub-Projekte
 
-[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/README.md)
+[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/)
 
 In diesem Repo lernen Sie einfache Möglichkeiten kennen, um Creative Commons-Lizenzen auf
 Github-Repositories per Markdown-Sprache anzuwenden.


### PR DESCRIPTION
Wrap lines to 80 characters per line when possible. Remove horizontal
rules from `README.md`. Make badge on translated README.md to return to
root instead to English `README.md`.
