### PR TITLE
Added italian translation

### DIFF
--- a/it/LICENSE-CC-BY
+++ b/it/LICENSE-CC-BY
@@ -1,0 +1,452 @@
+Attribuzione 4.0 Internazionale
+
+=======================================================================
+
+L'Associazione Creative Commons ("Creative Commons") non è uno studio
+legale e non fornisce servizi legali né consulenze legali. La
+distribuzione di licenze pubbliche Creative Commons non instaura un
+rapporto avvocato-cliente né rapporti di altro tipo. I modelli di
+licenza e tutte le relative informazioni fornite da Creative Commons
+sono da considerarsi "così come sono". Creative Commons non presta
+alcuna garanzia per i suoi modelli di licenza, per qualsiasi materiale
+concesso in licenza secondo i termini e le condizioni dei modelli di
+licenza, né per le relative informazioni. Creative Commons si esime nei
+più ampi limiti possibili da ogni responsabilità per i danni derivanti
+dall'utilizzo degli stessi
+
+Utilizzare le Licenze Pubbliche Creative Commons
+
+Le licenze pubbliche Creative Commons forniscono un modello di termini
+e condizioni che i creatori e altri detentori dei diritti possono
+utilizzare per condividere opere dell'ingegno originali ed altri 
+materiali oggetto di diritti d'autore e di altri diritti specificati
+dalla licenza pubblica di seguito. Le seguenti considerazioni hanno 
+una finalità esclusivamente informativa, non sono esaustive e non 
+costituiscono parte delle nostre licenze.
+
+     Considerazioni per i licenzianti: Le nostre licenze pubbliche sono
+     destinate all'uso da parte di coloro che sono autorizzati a dare al
+     pubblico il permesso di utilizzare il materiale secondo modalità
+     altrimenti limitate dal diritto d'autore e da altri diritti. Le
+     nostre licenze sono irrevocabili. I licenzianti devono leggere e
+     comprendere i termini e le condizioni della licenza che scelgono
+     prima di utilizzarla. I licenzianti devono inoltre assicurarsi di
+     detenere tutti i diritti necessari prima di utilizzare le nostre
+     licenze in modo che il pubblico possa riutilizzare il materiale
+     come previsto. I licenzianti devono contrassegnare in maniera
+     chiara tutti i materiali che non sono soggetti alla licenza. Questo
+     include altri materiali rilasciati con licenza Creative Commons
+     oppure materiali utilizzati in forza di eccezioni o limitazioni al
+     diritto d'autore.
+	wiki.creativecommons.org/Considerations_for_licensors_and_licensees
+
+     Considerazioni per il pubblico: Utilizzando una delle nostre
+     licenze pubbliche, il licenziante concede al pubblico il permesso
+     di utilizzare il materiale oggetto della licenza secondo
+     determinati termini e condizioni. Se l'autorizzazione del
+     licenziante non è necessaria per una qualsiasi ragione - ad
+     esempio nei casi in cui trovano applicazione eccezioni o
+     limitazioni al diritto d'autore - in quel caso l'utilizzo del
+     materiale non è regolato dalla licenza. Le nostre licenze
+     concedono unicamente quelle autorizzazioni relative al diritto
+     d'autore e certi altri diritti che un licenziante ha facoltà di
+     concedere. L'utilizzo del materiale rilasciato potrebbe essere
+     limitato per altri motivi, inclusi i casi in cui terze parti
+     detengano diritti d'autore o altri diritti sul materiale. Un
+     licenziante può avanzare richieste specifiche, come ad esempio
+     chiedere che ogni modifica al materiale venga contrassegnata o
+     descritta. Sebbene non sia richiesto dalle nostre licenze, sei
+     incoraggiato a rispettare queste richieste, ove ragionevole.
+	wiki.creativecommons.org/Considerations_for_licensors_and_licensees#Considerations_for_licensees
+
+=======================================================================
+Licenza Pubblica Creative Commons Attribuzione 4.0 Internazionale
+
+Con l'esercizio di uno qualunque dei Diritti Concessi in Licenza (sotto
+definiti), Tu accetti e Ti obblighi a rispettare integralmente i
+termini e le condizioni della presente Licenza Pubblica Creative
+Commons Attribuzione 4.0 Internazionale ("Licenza Pubblica"). Laddove
+la presente Licenza Pubblica possa essere qualificata come un
+contratto, Ti sono attribuiti i Diritti Concessi in Licenza a fronte
+della Tua accettazione di questi termini e condizioni, e il Licenziante
+Ti attribuisce tali diritti a fronte dei benefici che egli riceve
+rendendo il Materiale Concesso in Licenza disponibile secondo questi
+termini e condizioni.
+
+Articolo 1 –- Definizioni.
+
+  a. Materiale Elaborato significa materiale oggetto di Diritti
+     d'Autore e Simili, che derivi o sia basato sul Materiale Concesso
+     in Licenza nel quale il Materiale Concesso in Licenza sia
+     tradotto, alterato, arrangiato, trasformato o altrimenti
+     modificato, in una maniera che richieda il permesso ai sensi dei
+     Diritti d'Autore e Simili detenuti dal Licenziante. Ai fini della
+     presente Licenza Pubblica, laddove il Materiale Concesso in
+     Licenza sia una composizione musicale, un'esecuzione musicale o
+     una registrazione di suoni, la sincronizzazione del Materiale
+     Concesso in Licenza con un'immagine in movimento costituisce
+     sempre Materiale Elaborato.
+
+  b. Licenza dell'Elaboratore significa la licenza che Tu concedi per i
+     tuoi Diritti d'Autore e Simili sui Tuoi contributi al Materiale
+     Elaborato, conformemente ai termini e alle condizioni della
+     presente Licenza Pubblica.
+
+  c. Diritti d'Autore e Simili significa diritti d'autore e/o diritti
+     simili strettamente connessi al diritto d'autore, inclusi, fra gli
+     altri, l'esecuzione, la diffusione, la registrazione di suoni e il
+     Diritto Sui Generis sulle Banche Dati, comunque denominati o
+     classificati. Ai fini della presente Licenza Pubblica, i diritti
+     specificati all'interno degli Artt. 2(b)(1)-(2) non sono Diritti
+     d'Autore e Simili.
+
+  d. Misure Tecnologiche Efficaci significa quelle misure che, in
+     assenza di una specifica autorizzazione, non possono essere
+     aggirate secondo le norme che recepiscono gli obblighi previsti
+     dall'art. 11 del Trattato OMPI sul diritto d'autore adottato il 20
+     dicembre 1996 e/o simili accordi internazionali.
+
+  e. Eccezioni e Limitazioni significa qualunque eccezione e/o
+     limitazione ai Diritti D'Autore e Simili, inclusi "fair use" e
+     "fair dealing", che si applichi al Tuo utilizzo del Materiale
+     Concesso in Licenza.
+
+  f. Materiale Concesso in Licenza significa qualsiasi opera artistica
+     o letteraria, banca dati, o altro materiale al quale il
+     Licenziante abbia applicato la presente Licenza Pubblica.
+
+  g. Diritti Concessi in Licenza significa tutti i diritti che sono
+     concessi a Te nel rispetto dei termini e delle condizioni della
+     presente Licenza Pubblica, limitatamente ai Diritti d'Autore e
+     Simili che si applicano al Tuo utilizzo del Materiale Concesso in
+     Licenza e che il Licenziante ha facoltà di licenziare.
+
+  h. Licenziante significa l'individuo, gli individui, l'ente o gli
+     enti che concede o concedono diritti secondo la presente Licenza
+     Pubblica.
+
+  i. Condividi/Condividere significa fornire materiale al pubblico con
+     ogni mezzo di comunicazione o formato che richieda
+     l'autorizzazione rispetto ai Diritti Concessi in Licenza, come la
+     riproduzione, l'esposizione ed esecuzione in pubblico, la
+     distribuzione, la divulgazione, la comunicazione al pubblico,
+     l'importazione e la messa a disposizione del pubblico del
+     materiale, anche con modalità che consentano di accedere al
+     materiale da un luogo e in un momento scelti individualmente dal
+     pubblico.
+
+  j. Diritto Sui Generis sulle Banche Dati significa quei diritti
+     ulteriori rispetto al diritto d'autore individuati dalla Direttiva
+     96/9/CE del Parlamento europeo e del Consiglio, dell'11 marzo 1996
+     e successive modificazioni, relativa alla tutela giuridica delle
+     banche di dati, nonché altri diritti sostanzialmente
+     equivalenti previsti ovunque nel mondo.
+
+  k. Tu significa l'individuo o l'ente che esercita i Diritti Concessi
+     in Licenza secondo la presente Licenza Pubblica.
+     Te/Tuo/Tua/Tuoi/Ti hanno un significato analogo.
+
+Articolo 2 –- Ambito di Applicazione.
+
+  a. Concessione della Licenza.
+
+       1. Nel rispetto dei termini e delle condizioni contenute nella
+          presente Licenza Pubblica, il Licenziante concede a Te una
+          licenza per tutto il mondo, gratuita, non sub-licenziabile,
+          non esclusiva e irrevocabile che Ti autorizza ad esercitare i
+          Diritti Concessi in Licenza sul Materiale Concesso in Licenza
+          per:
+
+            a. riprodurre e Condividere il Materiale Concesso in
+               Licenza, in tutto o in parte; e
+
+            b. produrre, riprodurre e Condividere Materiale Elaborato.
+
+        2. Eccezioni e Limitazioni. Al fine di evitare dubbi, quando si
+           applicano delle Eccezioni o Limitazioni al Tuo utilizzo, la
+           presente Licenza Pubblica non si applica a Te e Tu non devi
+           rispettarne i termini e le condizioni.
+
+        3. Durata. La durata della presente Licenza Pubblica è
+           specificata all'interno dell'Art. 6(a).
+
+        4. Mezzi di comunicazione, supporti e formati; modifiche
+           tecniche consentite. Il Licenziante Ti autorizza a
+           esercitare i Diritti Concessi in Licenza con ogni mezzo di
+           comunicazione, su ogni supporto e in tutti i formati
+           esistenti e sviluppati in futuro, e ad apportare le
+           modifiche che si rendessero tecnicamente necessarie a tale
+           scopo. Il Licenziante rinuncia o si impegna a non far valere
+           alcun diritto o autorità per proibire a Te di effettuare le
+           modifiche che si rendessero tecnicamente necessarie per
+           l'esercizio dei Diritti Concessi in Licenza, incluse le
+           modifiche tecnicamente necessarie per aggirare Misure
+           Tecnologiche Efficaci. Ai fini della presente Licenza
+           Pubblica, apportare le modifiche autorizzate dal presente
+           Art. 2(a)(4) non costituisce in alcun caso Materiale
+           Elaborato.
+
+        5. Destinatari a valle.
+
+            a. Offerta dal Licenziante - Materiale Concesso in Licenza.
+               Ogni destinatario del Materiale Concesso in Licenza
+               riceve automaticamente un'offerta dal Licenziante ad
+               esercitare i Diritti Concessi in Licenza secondo i
+               termini e le condizioni della presente Licenza Pubblica.
+
+            b. Divieto di restrizioni a valle. Tu non puoi offrire o
+               imporre termini e condizioni aggiuntive o differenti al,
+               né applicare Misure Tecnologiche Efficaci sul, Materiale
+               Concesso in Licenza che abbiano per effetto di
+               restringere l'esercizio dei Diritti Concessi in Licenza
+               da parte di qualsiasi destinatario del Materiale
+               Concesso in Licenza.
+
+        6. Assenza di avallo. La presente Licenza Pubblica non concede
+           né può essere interpretata in modo da concedere
+           un'autorizzazione ad affermare o fare intendere che Tu o il
+           Tuo utilizzo del Materiale Concesso in Licenza siate
+           connessi, sponsorizzati, avallati o riconosciuti come
+           ufficiali dal Licenziante o da altre parti designate a
+           vedersi riconosciuta l'attribuzione in accordo con quanto
+           previsto all'interno dell'Art. 3(a)(1)(A)(i).
+
+  b. Altri Diritti.
+
+       1. I diritti morali, come il diritto all'integrità, non sono
+          oggetto della presente Licenza Pubblica, né lo sono il
+          diritto all'immagine, il diritto alla riservatezza e/o altri
+          simili diritti della personalità; in ogni caso, per quanto
+          possibile, il Licenziante rinuncia o si impegna a non far
+          valere alcuno dei diritti sopraccitati detenuti dal
+          Licenziante, unicamente nei limiti della misura che sia
+          indispensabile per consentire a Te di esercitare i Diritti
+          Concessi in Licenza.
+
+       2. I diritti su brevetti e marchi non sono oggetto della
+          presente Licenza Pubblica.
+
+       3. Per quanto possibile, il Licenziante rinuncia al diritto
+          esclusivo di riscuotere da Te i compensi per l'esercizio dei
+          Diritti Concessi in Licenza, personalmente o per tramite di
+          un ente di gestione collettiva, relativi a qualsiasi sistema
+          di licenza volontario o rinunciabile per legge o
+          obbligatorio. In tutti gli altri casi, il Licenziante si
+          riserva espressamente il diritto esclusivo a riscuotere tali
+          compensi.
+
+Articolo 3 –- Condizioni della Licenza.
+
+Il Tuo esercizio dei Diritti Concessi in Licenza è espressamente
+soggetto alle seguenti condizioni.
+
+  a. Attribuzione.
+
+       1. Se Tu Condividi il Materiale Concesso in Licenza (anche in
+          forma modificata), Tu sei tenuto a:
+
+            a. riportare, se fornito dal Licenziante assieme al
+               Materiale Concesso in Licenza, ciò che segue:
+
+                 i. l'identificazione del creatore o dei creatori del
+                    Materiale Concesso in Licenza e delle terze parti
+                    designate a ricevere l'attribuzione, in qualsiasi
+                    maniera ragionevole che sia richiesta dal
+                    Licenziante (incluso lo pseudonimo, se designato);
+
+                ii. l'informativa sul diritto d'autore;
+
+               iii. l'informativa che si riferisce alla presente
+                    Licenza Pubblica; 
+
+                iv. l'informativa contenente esclusioni o limitazioni
+                    di responsabilità;
+
+                 v. l'Uniform Resource Identifier (URI) o il
+                    collegamento ipertestuale alla presente Licenza
+                    Pubblica nella misura in cui sia ragionevolmente
+                    possibile;
+
+            b. indicare se Tu hai modificato il Materiale Concesso in
+               Licenza e, nel caso, conservare un'indicazione di ogni
+               modifica precedente; e
+
+            c. indicare che il Materiale Concesso in Licenza è
+               rilasciato secondo i termini e le condizioni della
+               presente Licenza Pubblica, e includere il testo della,
+               oppure l'URI o il collegamento ipertestuale alla,
+               presente Licenza Pubblica.
+
+       2. Tu puoi adempiere alle condizioni dell'Art. 3(a)(1) in
+          qualsiasi maniera ragionevole, rispetto al mezzo di
+          comunicazione, al supporto, agli strumenti e al contesto
+          all'interno del quale Tu Condividi il Materiale Concesso in
+          Licenza. Ad esempio, può essere ragionevole soddisfare le
+          condizioni fornendo l'URI o il collegamento ipertestuale a
+          una risorsa che includa le informazioni richieste.
+
+       3. Su richiesta del Licenziante, nella misura in cui ciò sia
+          ragionevolmente praticabile, Tu devi rimuovere ognuna delle
+          informazioni richieste dall'Art. 3(a)(1)(A).
+
+       4. Se Tu Condividi Materiale Elaborato da Te prodotto, la
+          Licenza dell'Elaboratore da Te applicata non deve impedire ai
+          destinatari del Materiale Elaborato di adempiere ai termini e
+          alle condizioni della presente Licenza Pubblica.
+
+Articolo 4 –- Diritto Sui Generis sulle Banche Dati.
+
+Laddove i Diritti Concessi in Licenza dovessero includere il Diritto
+Sui Generis sulle Banche Dati che si applichi al Tuo utilizzo del
+Materiale Concesso in Licenza:
+
+  a. al fine di evitare dubbi, l'Art. 2(a)(1) Ti concede il diritto di
+     estrarre, riutilizzare, riprodurre e Condividere tutti i contenuti
+     della banca dati o una loro parte sostanziale;
+
+  b. se Tu estrai tutti i contenuti della banca dati o una loro parte
+     sostanziale e li incorpori in una banca dati sulla quale Tu
+     detieni il Diritto Sui Generis sulle Banche Dati, allora la banca
+     dati sulla quale Tu detieni il Diritto Sui Generis sulle Banche
+     Dati (ma non i suoi singoli contenuti) costituisce Materiale
+     Elaborato; e
+
+  c. Tu devi adempiere le condizioni dell'Art. 3(a) se Tu Condividi
+     tutti i contenuti della banca dati o una loro parte sostanziale.
+
+Al fine di evitare dubbi, il presente Art. 4 si aggiunge ai, e non
+sostituisce i, Tuoi obblighi ai sensi della presente Licenza Pubblica,
+laddove i Diritti Concessi in Licenza dovessero includere Diritti
+d'Autore e Simili.
+
+Articolo 5 –- Esclusione di Garanzie e Limitazione di Responsabilità.
+
+  a. Laddove il Licenziante non si sia separatamente impegnato
+     altrimenti, per quanto possibile il Licenziante offre il Materiale
+     Concesso in Licenza "così com'è" e "come disponibile", e non
+     fornisce alcuna dichiarazione o garanzia di qualsiasi tipo con
+     riguardo al Materiale Concesso in Licenza, sia essa espressa o
+     implicita, di fonte legale o di altro tipo. Questo comprende, tra
+     le altre, le garanzie relative al titolo, alla commerciabilità,
+     all'idoneità per un fine specifico, alla non violazione di diritti
+     di terzi, alla mancanza di difetti latenti o di altro tipo,
+     all'esattezza o alla presenza o assenza di errori, siano o meno
+     conosciuti o conoscibili. Laddove l'esclusione di garanzie non
+     sia consentita in tutto o in parte, questa esclusione può non
+     essere applicabile a Te.
+
+  b. Per quanto possibile, il Licenziante non sarà in alcun caso
+     responsabile nei Tuoi confronti ad alcun titolo (incluso, tra gli
+     altri, la negligenza) o altrimenti per qualunque danno diretto,
+     speciale, indiretto, incidentale, consequenziale, punitivo,
+     esemplare, o altra perdita, costo, spesa o danno derivante dalla
+     presente Licenza Pubblica o dall'utilizzo del Materiale Concesso
+     in Licenza, anche nel caso in cui il Licenziante sia stato edotto
+     sulla possibilità di tali perdite, costi, spese o danni. Laddove
+     una limitazione di responsabilità non sia consentita in tutto o in
+     parte, questa limitazione può non essere applicabile a Te.
+
+  c. L'esclusione di garanzie e la limitazione di responsabilità di cui
+     sopra deve essere interpretata in maniera che, nei limiti
+     consentiti dalla legge applicabile, possa avvicinarsi quanto più
+     possibile ad una esclusione totale e a uno scarico di ogni
+     responsabilità.
+
+Articolo 6 –- Durata e Risoluzione.
+
+  a. La presente Licenza Pubblica è valida per tutta la durata dei
+     Diritti d'Autore e Simili oggetto della presente Licenza Pubblica.
+     Tuttavia, in caso di Tuo mancato adempimento dei termini e delle
+     condizioni della presente Licenza Pubblica, i diritti che Ti sono
+     concessi dalla presente Licenza Pubblica cesseranno
+     automaticamente.
+
+  b. Quando il Tuo diritto ad utilizzare il Materiale Concesso in
+     Licenza sia cessato secondo quanto previsto dall'Art. 6(a), tale
+     diritto è reintegrato:
+
+       1. automaticamente a partire dal momento in cui il mancato
+          adempimento è sanato, purché ciò si verifichi entro trenta
+          giorni dal momento in cui Tu sei venuto a conoscenza del
+          mancato adempimento; oppure
+
+       2. su espressa reintegrazione da parte del Licenziante.
+
+  Al fine di evitare dubbi, il presente Art. 6(b) non pregiudica alcun
+  diritto di cui il Licenziante sia titolare al fine di ottenere rimedi
+  a fronte della violazione da parte Tua della presente Licenza 
+  Pubblica.
+
+  c. Al fine di evitare dubbi, il Licenziante si riserva il diritto di
+     rilasciare il Materiale Concesso in Licenza sulla base di termini
+     e condizioni separati da quelli della presente Licenza Pubblica o
+     di cessare la distribuzione del Materiale Concesso in Licenza in
+     qualsiasi momento; in ogni caso, tali decisioni non comporteranno
+     la risoluzione della presente Licenza Pubblica.
+
+  d. Gli Artt. 1, 5, 6, 7 e 8 rimangono validi in caso di risoluzione
+     della presente Licenza.
+
+Articolo 7 –- Altri Termini e Condizioni.
+
+  a. Il Licenziante non sarà vincolato ad alcun altro termine o
+     condizione aggiuntivo o differente che provenga da Te, salvo che
+     ciò venga espressamente consentito.
+
+  b. Ogni intesa, patto o accordo aggiuntivo riguardo al Materiale
+     Concesso in Licenza non contenuto nella presente è da considerarsi
+     separato ed indipendente dai termini e dalle condizioni della
+     presente Licenza Pubblica.
+
+Articolo 8 –- Interpretazione.
+
+  a. Al fine di evitare dubbi, la presente Licenza Pubblica non
+     intende, né deve essere interpretata in modo da ridurre, limitare,
+     restringere o condizionare alcun utilizzo del Materiale Concesso
+     in Licenza che sia lecito anche in assenza di autorizzazione ai
+     sensi della presente Licenza Pubblica.
+
+  b. Nei limiti consentiti dalla legge applicabile, qualora una o più
+     disposizioni della presente Licenza Pubblica siano giudicate
+     invalide o inefficaci, saranno da intendersi rettificate nei
+     limiti della misura che sia indispensabile per renderle valide ed
+     efficaci. Se una o più disposizioni non possono essere
+     rettificate, dovranno essere eliminate dalla presente Licenza
+     Pubblica senza comportare l'invalidità o l'inefficacia dei
+     restanti termini e condizioni.
+
+  c. In nessun caso i termini e le condizioni di cui alla presente
+     Licenza Pubblica possono essere rinunciati né alcun mancato
+     adempimento può essere consentito, salvo che tale rinuncia o
+     consenso venga espressamente autorizzato dal Licenziante.
+
+  d. Nessuna parte della presente Licenza Pubblica può in alcun modo
+     costituire o essere interpretata come una limitazione o una
+     rinuncia a qualsiasi privilegio o immunità che possa applicarsi al
+     Licenziante o a Te, inclusi quelli derivanti dai procedimenti
+     giudiziari di qualsivoglia giurisdizione o autorità.
+
+
+=======================================================================
+
+Creative Commons non è una delle parti rispetto alle sue licenze
+pubbliche. Ciò nonostante, Creative Commons può decidere di applicare
+una delle sue licenze pubbliche a materiale di sua pubblicazione, nel
+qual caso sarà considerata, relativamente ad esso, il "Licenziante". Il
+testo delle licenze pubbliche Creative Commons è dedicato al pubblico
+dominio secondo i termini della
+creativecommons.org/publicdomain/zero/1.0/legalcode.it
+Donazione al Pubblico Dominio CC0. Salvo che per il solo scopo di
+indicare che il materiale è rilasciato secondo i termini e le
+condizioni di una licenza pubblica Creative Commons o come altrimenti
+consentito dalle policy di Creative Commons consultabili all'indirizzo
+creativecommons.org/policies, Creative Commons non autorizza l'utilizzo
+del marchio "Creative Commons" o di qualsiasi altro marchio o logo di
+Creative Commons senza il suo preventivo consenso scritto, incluso, fra
+gli altri, quello in connessione con qualsiasi modifica non autorizzata
+alle sue licenze pubbliche o con qualsiasi altra intesa, patto o
+accordo circa l'utilizzo del materiale concesso in licenza. Al fine di
+evitare dubbi, è inteso che questo paragrafo non fa parte delle licenze
+pubbliche.
+
+Creative Commons può essere contattata al sito creativecommons.org.

--- a/it/LICENSE-CC-BY-NC-SA
+++ b/it/LICENSE-CC-BY-NC-SA
@@ -1,0 +1,506 @@
+Attribuzione-NonCommerciale-CondividiAlloStessoModo 4.0 Internazionale
+
+=======================================================================
+
+L'Associazione Creative Commons ("Creative Commons") non è uno studio
+legale e non fornisce servizi legali né consulenze legali. La
+distribuzione di licenze pubbliche Creative Commons non instaura un
+rapporto avvocato-cliente né rapporti di altro tipo. I modelli di
+licenza e tutte le relative informazioni fornite da Creative Commons
+sono da considerarsi "così come sono". Creative Commons non presta
+alcuna garanzia per i suoi modelli di licenza, per qualsiasi materiale
+concesso in licenza secondo i termini e le condizioni dei modelli di
+licenza, né per le relative informazioni. Creative Commons si esime nei
+più ampi limiti possibili da ogni responsabilità per i danni derivanti
+dall'utilizzo degli stessi.
+
+Utilizzare le Licenze Pubbliche Creative Commons
+
+Le licenze pubbliche Creative Commons forniscono un modello di termini
+e condizioni che i creatori e altri detentori dei diritti possono
+utilizzare per condividere opere dell'ingegno originali ed altri
+materiali oggetto di diritti d'autore e di altri diritti specificati
+dalla licenza pubblica di seguito. Le seguenti considerazioni hanno una
+finalità esclusivamente informativa, non sono esaustive e non
+costituiscono parte delle nostre licenze.
+
+     Considerazioni per i licenzianti: Le nostre licenze pubbliche sono
+     destinate all'uso da parte di coloro che sono autorizzati a dare
+     al pubblico il permesso di utilizzare il materiale secondo
+     modalità altrimenti limitate dal diritto d'autore e da altri
+     diritti. Le nostre licenze sono irrevocabili. I licenzianti devono
+     leggere e comprendere i termini e le condizioni della licenza che
+     scelgono prima di utilizzarla. I licenzianti devono inoltre
+     assicurarsi di detenere tutti i diritti necessari prima di
+     utilizzare le nostre licenze in modo che il pubblico possa
+     riutilizzare il materiale come previsto. I licenzianti devono
+     contrassegnare in maniera chiara tutti i materiali che non sono
+     soggetti alla licenza. Questo include altri materiali rilasciati
+     con licenza Creative Commons oppure materiali utilizzati in forza
+     di eccezioni o limitazioni al diritto d'autore.
+    wiki.creativecommons.org/Considerations_for_licensors_and_licensees
+     
+     Considerazioni per il pubblico: Utilizzando una delle nostre
+     licenze pubbliche, il licenziante concede al pubblico il permesso
+     di utilizzare il materiale oggetto della licenza secondo
+     determinati termini e condizioni. Se l'autorizzazione del
+     licenziante non è necessaria per una qualsiasi ragione - ad
+     esempio nei casi in cui trovano applicazione eccezioni o
+     limitazioni al diritto d'autore - in quel caso l'utilizzo del
+     materiale non è regolato dalla licenza. Le nostre licenze
+     concedono unicamente quelle autorizzazioni relative al diritto
+     d'autore e certi altri diritti che un licenziante ha facoltà di
+     concedere. L'utilizzo del materiale rilasciato potrebbe essere
+     limitato per altri motivi, inclusi i casi in cui terze parti
+     detengano diritti d'autore o altri diritti sul materiale. Un
+     licenziante può avanzare richieste specifiche, come ad esempio
+     chiedere che ogni modifica al materiale venga contrassegnata o
+     descritta. Sebbene non sia richiesto dalle nostre licenze, sei
+     incoraggiato a rispettare queste richieste, ove ragionevole.
+    wiki.creativecommons.org/Considerations_for_licensors_and_licensees
+
+Licenza Pubblica Creative Commons 
+Attribuzione-NonCommerciale-CondividiAlloStessoModo 4.0 Internazionale
+
+Con l'esercizio di uno qualunque dei Diritti Concessi in Licenza (sotto
+definiti), Tu accetti e Ti obblighi a rispettare integralmente i
+termini e le condizioni della presente Licenza Pubblica Creative
+Commons Attribuzione-NonCommerciale-CondividiAlloStessoModo 4.0
+Internazionale ("Licenza Pubblica"). Laddove la presente Licenza
+Pubblica possa essere qualificata come un contratto, Ti sono attribuiti
+i Diritti Concessi in Licenza a fronte della Tua accettazione di questi
+termini e condizioni, e il Licenziante Ti attribuisce tali diritti a
+fronte dei benefici che egli riceve rendendo il Materiale Concesso in
+Licenza disponibile secondo questi termini e condizioni.
+
+Articolo 1 -- Definizioni.
+
+  a. Materiale Elaborato significa materiale oggetto di Diritti
+     d'Autore e Simili, che derivi o sia basato sul Materiale Concesso
+     in Licenza nel quale il Materiale Concesso in Licenza sia
+     tradotto, alterato, arrangiato, trasformato o altrimenti
+     modificato, in una maniera che richieda il permesso ai sensi dei
+     Diritti d'Autore e Simili detenuti dal Licenziante. Ai fini della
+     presente Licenza Pubblica, laddove il Materiale Concesso in
+     Licenza sia una composizione musicale, un'esecuzione musicale o
+     una registrazione di suoni, la sincronizzazione del Materiale
+     Concesso in Licenza con un'immagine in movimento costituisce
+     sempre Materiale Elaborato.
+
+  b. Licenza dell'Elaboratore significa la licenza che Tu concedi per
+     i tuoi Diritti d'Autore e Simili sui Tuoi contributi al Materiale
+     Elaborato, conformemente ai termini e alle condizioni della
+     presente Licenza Pubblica.
+
+  b. Licenza Compatibile con BY-NC-SA significa una licenza elencata
+     all'indirizzo creativecommons.org/compatiblelicenses ed approvata
+     da Creative Commons come sostanzialmente equivalente alla presente
+     Licenza Pubblica.
+
+  d. Diritti d'Autore e Simili significa diritti d'autore e/o diritti
+     simili strettamente connessi al diritto d'autore, inclusi, fra gli
+     altri, l'esecuzione, la diffusione, la registrazione di suoni e il
+     Diritto Sui Generis sulle Banche Dati, comunque denominati o
+     classificati. Ai fini della presente Licenza Pubblica, i diritti
+     specificati all'interno degli Artt. 2(b)(1)-(2) non sono Diritti
+     d'Autore e Simili.
+
+  e. Misure Tecnologiche Efficaci significa quelle misure che, in
+     assenza di una specifica autorizzazione, non possono essere
+     aggirate secondo le norme che recepiscono gli obblighi previsti
+     dall'art. 11 del Trattato OMPI sul diritto d'autore adottato il
+     20 dicembre 1996 e/o simili accordi internazionali.
+
+  f. Eccezioni e Limitazioni significa qualunque eccezione e/o
+     limitazione ai Diritti D'Autore e Simili, inclusi "fair use" e
+     "fair dealing", che si applichi al Tuo utilizzo del Materiale
+     Concesso in Licenza.
+
+  g. Elementi della Licenza significa gli attributi fondamentali
+     indicati nel nome di una Licenza Pubblica Creative Commons.
+     Gli Elementi della Licenza della presente Licenza Pubblica sono
+     Attribuzione, NonCommerciale e CondividiAlloStessoModo.
+
+  h. Materiale Concesso in Licenza significa qualsiasi opera artistica
+     o letteraria, banca dati, o altro materiale al quale il
+     Licenziante abbia applicato la presente Licenza Pubblica.
+
+  i. Diritti Concessi in Licenza significa tutti i diritti che sono
+     concessi a Te nel rispetto dei termini e delle condizioni della
+     presente Licenza Pubblica, limitatamente ai Diritti d'Autore e
+     Simili che si applicano al Tuo utilizzo del Materiale Concesso in
+     Licenza e che il Licenziante ha facoltà di licenziare.
+
+  j. Licenziante significa l'individuo, gli individui, l'ente o gli
+     enti che concede o concedono diritti secondo la presente
+     Licenza Pubblica.
+
+  k. NonCommerciale significa in una maniera tale che non sia
+     prevalentemente intesa o diretta al perseguimento di un vantaggio
+     commerciale o di un compenso monetario. Ai fini della presente
+     Licenza Pubblica, lo scambio del Materiale Concesso in Licenza con
+     altri materiali protetti dal Diritto d'Autore e Simili per mezzo
+     della condivisione digitale di file (c.d. filesharing) o simili
+     modalità è considerato NonCommerciale, a patto che non ci sia
+     pagamento di alcun compenso monetario in connessione allo scambio.
+
+  l. Condividi/Condividere significa fornire materiale al pubblico con
+     ogni mezzo di comunicazione o formato che richieda
+     l'autorizzazione rispetto ai Diritti Concessi in Licenza, come la
+     riproduzione, l'esposizione ed esecuzione in pubblico, la
+     distribuzione, la divulgazione, la comunicazione al pubblico,
+     l'importazione e la messa a disposizione del pubblico del
+     materiale, anche con modalità che consentano di accedere al
+     materiale da un luogo e in un momento scelti individualmente
+     dal pubblico.
+
+  m. Diritto Sui Generis sulle Banche Dati significa quei diritti
+     ulteriori rispetto al diritto d'autore individuati dalla
+     Direttiva 96/9/CE del Parlamento europeo e del Consiglio,
+     dell'11 marzo 1996 e successive modificazioni, relativa alla
+     tutela giuridica delle banche di dati, nonché altri diritti
+     sostanzialmente equivalenti previsti ovunque nel mondo.
+
+  n. Tu significa l'individuo o l'ente che esercita i Diritti Concessi
+     in Licenza secondo la presente Licenza Pubblica. 
+     Te/Tuo/Tua/Tuoi/Ti hanno un significato analogo.
+
+Articolo 2 –- Ambito di Applicazione.
+
+  a. Concessione della Licenza.
+
+       1. Nel rispetto dei termini e delle condizioni contenute nella
+          presente Licenza Pubblica, il Licenziante concede a Te una
+          licenza per tutto il mondo, gratuita, non sub-licenziabile,
+          non esclusiva e irrevocabile che Ti autorizza ad esercitare
+          i Diritti Concessi in Licenza sul Materiale Concesso in
+          Licenza per:
+
+            a. riprodurre e Condividere il Materiale Concesso in
+               Licenza, in tutto o in parte, esclusivamente per scopi
+               di tipo NonCommerciale; e
+
+            b. produrre, riprodurre e Condividere Materiale Elaborato
+               esclusivamente per scopi di tipo NonCommerciale.
+
+       2. Eccezioni e Limitazioni. Al fine di evitare dubbi, quando si
+          applicano delle Eccezioni o Limitazioni al Tuo utilizzo, la
+          presente Licenza Pubblica non si applica a Te e Tu non devi
+          rispettarne i termini e le condizioni.
+
+       3. Durata. La durata della presente Licenza Pubblica è
+          specificata all'interno dell'Art. 6(a).
+
+       4. Mezzi di comunicazione, supporti e formati; modifiche
+          tecniche consentite. Il Licenziante Ti autorizza a esercitare
+          i Diritti Concessi in Licenza con ogni mezzo di
+          comunicazione, su ogni supporto e in tutti i formati
+          esistenti e sviluppati in futuro, e ad apportare le modifiche
+          che si rendessero tecnicamente necessarie a tale scopo. Il
+          Licenziante rinuncia o si impegna a non far valere alcun
+          diritto o autorità per proibire a Te di effettuare le
+          modifiche che si rendessero tecnicamente necessarie per
+          l'esercizio dei Diritti Concessi in Licenza, incluse le
+          modifiche tecnicamente necessarie per aggirare Misure
+          Tecnologiche Efficaci. Ai fini della presente Licenza
+          Pubblica, apportare le modifiche autorizzate dal presente
+          Art. 2(a)(4) non costituisce in alcun caso Materiale
+          Elaborato.
+
+       5. Destinatari a valle.
+
+            a. Offerta dal Licenziante - Materiale Concesso in Licenza.
+               Ogni destinatario del Materiale Concesso in Licenza
+               riceve automaticamente un'offerta dal Licenziante ad
+               esercitare i Diritti Concessi in Licenza secondo i
+               termini e le condizioni della presente Licenza Pubblica.
+
+            b. Offerta aggiuntiva dal Licenziante - Materiale
+               Elaborato. Ogni destinatario del Materiale Elaborato da
+               parte Tua riceve automaticamente un'offerta dal
+               Licenziante ad esercitare i Diritti Concessi in Licenza
+               sul Materiale Elaborato secondo i termini e le
+               condizioni della Licenza dell'Elaboratore da Te
+               applicata.
+
+            c. Divieto di restrizioni a valle. Tu non puoi offrire o
+               imporre termini e condizioni aggiuntive o differenti al,
+               né applicare Misure Tecnologiche Efficaci sul, Materiale
+               Concesso in Licenza che abbiano per effetto di
+               restringere l'esercizio dei Diritti Concessi in Licenza
+               da parte di qualsiasi destinatario del Materiale
+               Concesso in Licenza.
+
+       6. Assenza di avallo. La presente Licenza Pubblica non concede
+          né può essere interpretata in modo da concedere
+          un'autorizzazione ad affermare o fare intendere che Tu o il
+          Tuo utilizzo del Materiale Concesso in Licenza siate
+          connessi, sponsorizzati, avallati o riconosciuti come
+          ufficiali dal Licenziante o da altre parti designate a
+          vedersi riconosciuta l'attribuzione in accordo con quanto
+          previsto all'interno dell'Art. 3(a)(1)(A)(i).
+
+  b. Altri Diritti.
+
+       1. I diritti morali, come il diritto all'integrità, non sono
+          oggetto della presente Licenza Pubblica, né lo sono il
+          diritto all'immagine, il diritto alla riservatezza e/o altri
+          simili diritti della personalità; in ogni caso, per quanto
+          possibile, il Licenziante rinuncia o si impegna a non far
+          valere alcuno dei diritti sopraccitati detenuti dal
+          Licenziante, unicamente nei limiti della misura che sia
+          indispensabile per consentire a Te di esercitare i
+          Diritti Concessi in Licenza.
+
+       2. I diritti su brevetti e marchi non sono oggetto della
+          presente Licenza Pubblica.
+
+       3. Per quanto possibile, il Licenziante rinuncia al diritto
+          esclusivo di riscuotere da Te i compensi per l'esercizio dei
+          Diritti Concessi in Licenza, personalmente o per tramite di
+          un ente di gestione collettiva, relativi a qualsiasi sistema
+          di licenza volontario o rinunciabile per legge o
+          obbligatorio. In tutti gli altri casi, il Licenziante si
+          riserva espressamente il diritto esclusivo a riscuotere tali
+          compensi, incluso il caso in cui il Materiale Concesso in
+          Licenza sia utilizzato per scopi diversi da quelli di tipo
+          NonCommerciale.
+
+
+Articolo 3 -– Condizioni della Licenza.
+
+Il Tuo esercizio dei Diritti Concessi in Licenza è espressamente
+soggetto alle seguenti condizioni.
+
+  a. Attribuzione.
+
+       1. Se Tu Condividi il Materiale Concesso in Licenza (anche in
+          forma modificata), Tu sei tenuto a:
+
+            a. riportare, se fornito dal Licenziante assieme al
+               Materiale Concesso in Licenza, ciò che segue:
+
+                 i. l'identificazione del creatore o dei creatori del
+                    Materiale Concesso in Licenza e delle terze parti
+                    designate a ricevere l'attribuzione, in qualsiasi
+                    maniera ragionevole che sia richiesta dal
+                    Licenziante (incluso lo pseudonimo, se designato);
+
+                ii. l'informativa sul diritto d'autore;
+
+               iii. l'informativa che si riferisce alla presente
+                    Licenza Pubblica; 
+
+                iv. l'informativa contenente esclusioni o limitazioni
+                    di responsabilità;
+
+                 v. l'Uniform Resource Identifier (URI) o il
+                    collegamento ipertestuale alla presente Licenza
+                    Pubblica nella misura in cui sia ragionevolmente
+                    possibile;
+
+            b. indicare se Tu hai modificato il Materiale Concesso in
+               Licenza e, nel caso, conservare un'indicazione di ogni
+               modifica precedente; e
+
+            c. indicare che il Materiale Concesso in Licenza è
+               rilasciato secondo i termini e le condizioni della
+               presente Licenza Pubblica, e includere il testo della,
+               oppure l'URI o il collegamento ipertestuale alla,
+               presente Licenza Pubblica.
+
+       2. Tu puoi adempiere alle condizioni dell'Art. 3(a)(1) in
+          qualsiasi maniera ragionevole, rispetto al mezzo di
+          comunicazione, al supporto, agli strumenti e al contesto
+          all'interno del quale Tu Condividi il Materiale Concesso in
+          Licenza. Ad esempio, può essere ragionevole soddisfare le
+          condizioni fornendo l'URI o il collegamento ipertestuale a
+          una risorsa che includa le informazioni richieste.
+
+       3. Su richiesta del Licenziante, nella misura in cui ciò sia
+          ragionevolmente praticabile, Tu devi rimuovere ognuna delle
+          informazioni richieste dall'Art. 3(a)(1)(A).
+
+  b. CondividiAlloStessoModo.
+
+     In aggiunta alle condizioni previste all'interno dell'Art. 3(a)
+     di cui sopra, se Tu Condividi Materiale Elaborato da Te prodotto,
+     si applicano anche le seguenti condizioni.
+
+       1. La Licenza dell'Elaboratore da Te applicata deve essere una
+          licenza Creative Commons, nella versione attuale o
+          successiva, dotata degli stessi Elementi della Licenza,
+          oppure una Licenza Compatibile con BY-NC-SA.
+
+       2. Tu devi includere il testo della, oppure l'URI o il
+          collegamento ipertestuale alla, Licenza dell'Elaboratore da
+          Te applicata. Tu puoi adempiere a questa condizione in
+          qualsiasi maniera ragionevole possibile, rispetto al mezzo di
+          comunicazione, al supporto, agli strumenti e al contesto
+          all'interno del quale Tu Condividi il Materiale Elaborato.
+
+       3. Tu non puoi offrire o imporre termini e condizioni aggiuntive
+          o differenti al, né applicare Misure Tecnologiche Efficaci
+          sul Materiale Elaborato che abbiano per effetto di
+          restringere l'esercizio dei diritti concessi secondo i
+          termini e le condizioni della Licenza dell'Elaboratore da
+          Te applicata.
+
+
+Articolo 4 -– Diritto Sui Generis sulle Banche Dati.
+
+Laddove i Diritti Concessi in Licenza dovessero includere il Diritto
+Sui Generis sulle Banche Dati che si applichi al Tuo utilizzo del
+Materiale Concesso in Licenza:
+
+  a. al fine di evitare dubbi, l'Art. 2(a)(1) Ti concede il diritto di
+     estrarre, riutilizzare, riprodurre e Condividere tutti i contenuti
+     della banca dati o una loro parte sostanziale esclusivamente per
+     scopi di tipo NonCommerciale;
+
+  b. se Tu estrai tutti i contenuti della banca dati o una loro parte
+     sostanziale e li incorpori in una banca dati sulla quale Tu
+     detieni il Diritto Sui Generis sulle Banche Dati, allora la banca
+     dati sulla quale Tu detieni il Diritto Sui Generis sulle Banche
+     Dati (ma non i suoi singoli contenuti) costituisce Materiale
+     Elaborato, anche ai fini dell'Art. 3(b); e
+
+  c. Tu devi adempiere le condizioni dell'Art. 3(a) se Tu Condividi
+     tutti i contenuti della banca dati o una loro parte sostanziale.
+
+Al fine di evitare dubbi, il presente Art. 4 si aggiunge ai, e non
+sostituisce i, Tuoi obblighi ai sensi della presente Licenza Pubblica,
+laddove i Diritti Concessi in Licenza dovessero includere Diritti
+d'Autore e Simili.
+
+Articolo 5 –- Esclusione di Garanzie e Limitazione di Responsabilità.
+
+  a. Laddove il Licenziante non si sia separatamente impegnato
+     altrimenti, per quanto possibile il Licenziante offre il
+     Materiale Concesso in Licenza "così com'è" e "come disponibile",
+     e non fornisce alcuna dichiarazione o garanzia di qualsiasi tipo
+     con riguardo al Materiale Concesso in Licenza, sia essa espressa
+     o implicita, di fonte legale o di altro tipo. Questo comprende,
+     tra le altre, le garanzie relative al titolo, alla
+     commerciabilità, all'idoneità per un fine specifico, alla non
+     violazione di diritti di terzi, alla mancanza di difetti latenti
+     o di altro tipo, all'esattezza o alla presenza o assenza di
+     errori, siano o meno conosciuti o conoscibili. Laddove
+     l'esclusione di garanzie non sia consentita in tutto o in parte,
+     questa esclusione può non essere applicabile a Te.
+
+  b. Per quanto possibile, il Licenziante non sarà in alcun caso
+     responsabile nei Tuoi confronti ad alcun titolo (incluso, tra gli
+     altri, la negligenza) o altrimenti per qualunque danno diretto,
+     speciale, indiretto, incidentale, consequenziale, punitivo,
+     esemplare, o altra perdita, costo, spesa o danno derivante dalla
+     presente Licenza Pubblica o dall'utilizzo del Materiale Concesso
+     in Licenza, anche nel caso in cui il Licenziante sia stato edotto
+     sulla possibilità di tali perdite, costi, spese o danni. Laddove
+     una limitazione di responsabilità non sia consentita in tutto o
+     in parte, questa limitazione può non essere applicabile a Te.
+
+  c. L'esclusione di garanzie e la limitazione di responsabilità di cui
+     sopra deve essere interpretata in maniera che, nei limiti
+     consentiti dalla legge applicabile, possa avvicinarsi quanto più
+     possibile ad una esclusione totale e a uno scarico di ogni
+     responsabilità.
+
+Articolo 6 –- Durata e Risoluzione.
+
+  a. La presente Licenza Pubblica è valida per tutta la durata dei
+     Diritti d'Autore e Simili oggetto della presente Licenza Pubblica.
+     Tuttavia, in caso di Tuo mancato adempimento dei termini e delle
+     condizioni della presente Licenza Pubblica, i diritti che Ti sono
+     concessi dalla presente Licenza Pubblica cesseranno 
+     automaticamente.
+
+  b. Quando il Tuo diritto ad utilizzare il Materiale Concesso in
+     Licenza sia cessato secondo quanto previsto dall'Art. 6(a), tale
+     diritto è reintegrato:
+     
+       1. automaticamente a partire dal momento in cui il mancato
+          adempimento è sanato, purché ciò si verifichi entro trenta
+          giorni dal momento in cui Tu sei venuto a conoscenza del
+          mancato adempimento; oppure
+
+       2. su espressa reintegrazione da parte del Licenziante.
+
+     Al fine di evitare dubbi, il presente Art. 6(b) non pregiudica
+     alcun diritto di cui il Licenziante sia titolare al fine di
+     ottenere rimedi a fronte della violazione da parte Tua della
+     presente Licenza Pubblica.
+
+  c. Al fine di evitare dubbi, il Licenziante si riserva il diritto di
+     rilasciare il Materiale Concesso in Licenza sulla base di termini
+     e condizioni separati da quelli della presente Licenza Pubblica o
+     di cessare la distribuzione del Materiale Concesso in Licenza in
+     qualsiasi momento; in ogni caso, tali decisioni non comporteranno
+     la risoluzione della presente Licenza Pubblica.
+
+  d. Gli Artt. 1, 5, 6, 7 e 8 rimangono validi in caso di risoluzione
+     della presente Licenza.
+
+Articolo 7 –- Altri Termini e Condizioni.
+
+  a. Il Licenziante non sarà vincolato ad alcun altro termine o
+     condizione aggiuntivo o differente che provenga da Te, salvo che
+     ciò venga espressamente consentito.
+
+  b. Ogni intesa, patto o accordo aggiuntivo riguardo al Materiale
+     Concesso in Licenza non contenuto nella presente è da considerarsi
+     separato ed indipendente dai termini e dalle condizioni della
+     presente Licenza Pubblica.
+
+
+Articolo 8 –- Interpretazione.
+
+  a. Al fine di evitare dubbi, la presente Licenza Pubblica non
+     intende, né deve essere interpretata in modo da ridurre, limitare,
+     restringere o condizionare alcun utilizzo del Materiale Concesso
+     in Licenza che sia lecito anche in assenza di autorizzazione ai
+     sensi della presente Licenza Pubblica.
+
+  b. Nei limiti consentiti dalla legge applicabile, qualora una o più
+     disposizioni della presente Licenza Pubblica siano giudicate
+     invalide o inefficaci, saranno da intendersi rettificate nei
+     limiti della misura che sia indispensabile per renderle valide ed
+     efficaci. Se una o più disposizioni non possono essere
+     rettificate, dovranno essere eliminate dalla presente Licenza
+     Pubblica senza comportare l'invalidità o l'inefficacia dei
+     restanti termini e condizioni.
+
+  c. In nessun caso i termini e le condizioni di cui alla presente
+     Licenza Pubblica possono essere rinunciati né alcun mancato
+     adempimento può essere consentito, salvo che tale rinuncia o
+     consenso venga espressamente autorizzato dal Licenziante.
+
+  d. Nessuna parte della presente Licenza Pubblica può in alcun modo
+     costituire o essere interpretata come una limitazione o una
+     rinuncia a qualsiasi privilegio o immunità che possa applicarsi
+     al Licenziante o a Te, inclusi quelli derivanti dai procedimenti
+     giudiziari di qualsivoglia giurisdizione o autorità.
+
+=======================================================================
+
+Creative Commons non è una delle parti rispetto alle sue licenze
+pubbliche. Ciò nonostante, Creative Commons può decidere di applicare
+una delle sue licenze pubbliche a materiale di sua pubblicazione, nel
+qual caso sarà considerata, relativamente ad esso, il "Licenziante".
+Il testo delle licenze pubbliche Creative Commons è dedicato al
+pubblico dominio secondo i termini della 
+creativecommons.org/publicdomain/zero/1.0/legalcode.it
+Donazione al Pubblico Dominio CC0. Salvo che per il solo scopo di
+indicare che il materiale è rilasciato secondo i termini e le
+condizioni di una licenza pubblica Creative Commons o come altrimenti
+consentito dalle policy di Creative Commons consultabili all'indirizzo
+creativecommons.org/policies, Creative Commons non autorizza l'utilizzo
+del marchio "Creative Commons" o di qualsiasi altro marchio o logo di
+Creative Commons senza il suo preventivo consenso scritto, incluso, fra
+gli altri, quello in connessione con qualsiasi modifica non autorizzata
+alle sue licenze pubbliche o con qualsiasi altra intesa, patto o
+accordo circa l'utilizzo del materiale concesso in licenza. Al fine di
+evitare dubbi, è inteso che questo paragrafo non fa parte delle
+licenze pubbliche.
+
+Creative Commons può essere contattata al sito creativecommons.org

--- a/it/LICENSE-CC-BY-SA
+++ b/it/LICENSE-CC-BY-SA
@@ -1,0 +1,494 @@
+Attribuzione-CondividiAlloStessoModo 4.0 Internazionale
+
+=======================================================================
+
+L'Associazione Creative Commons ("Creative Commons") non è uno studio
+legale e non fornisce servizi legali né consulenze legali. La
+distribuzione di licenze pubbliche Creative Commons non instaura un
+rapporto avvocato-cliente né rapporti di altro tipo. I modelli di
+licenza e tutte le relative informazioni fornite da Creative Commons
+sono da considerarsi "così come sono". Creative Commons non presta
+alcuna garanzia per i suoi modelli di licenza, per qualsiasi materiale
+concesso in licenza secondo i termini e le condizioni dei modelli di
+licenza, né per le relative informazioni. Creative Commons si esime nei
+più ampi limiti possibili da ogni responsabilità per i danni derivanti
+dall'utilizzo degli stessi.
+
+Utilizzare le Licenze Pubbliche Creative Commons
+
+Le licenze pubbliche Creative Commons forniscono un modello di termini
+e condizioni che i creatori e altri detentori dei diritti possono
+utilizzare per condividere opere dell'ingegno originali ed altri
+materiali oggetto di diritti d'autore e di altri diritti specificati
+dalla licenza pubblica di seguito. Le seguenti considerazioni hanno una
+finalità esclusivamente informativa, non sono esaustive e non
+costituiscono parte delle nostre licenze.
+
+     Considerazioni per i licenzianti: Le nostre licenze pubbliche sono
+     destinate all'uso da parte di coloro che sono autorizzati a dare
+     al pubblico il permesso di utilizzare il materiale secondo
+     modalità altrimenti limitate dal diritto d'autore e da altri
+     diritti. Le nostre licenze sono irrevocabili. I licenzianti devono
+     leggere e comprendere i termini e le condizioni della licenza che
+     scelgono prima di utilizzarla. I licenzianti devono inoltre
+     assicurarsi di detenere tutti i diritti necessari prima di
+     utilizzare le nostre licenze in modo che il pubblico possa
+     riutilizzare il materiale come previsto. I licenzianti devono
+     contrassegnare in maniera chiara tutti i materiali che non sono
+     soggetti alla licenza. Questo include altri materiali rilasciati
+     con licenza Creative Commons oppure materiali utilizzati in forza
+     di eccezioni o limitazioni al diritto d'autore. 
+	wiki.creativecommons.org/Considerations_for_licensors_and_licensees
+
+     Considerazioni per il pubblico: Utilizzando una delle nostre
+     licenze pubbliche, il licenziante concede al pubblico il permesso
+     di utilizzare il materiale oggetto della licenza secondo
+     determinati termini e condizioni. Se l'autorizzazione del
+     licenziante non è necessaria per una qualsiasi ragione - ad
+     esempio nei casi in cui trovano applicazione eccezioni o
+     limitazioni al diritto d'autore - in quel caso l'utilizzo del
+     materiale non è regolato dalla licenza. Le nostre licenze
+     concedono unicamente quelle autorizzazioni relative al diritto
+     d'autore e certi altri diritti che un licenziante ha facoltà di
+     concedere. L'utilizzo del materiale rilasciato potrebbe essere
+     limitato per altri motivi, inclusi i casi in cui terze parti
+     detengano diritti d'autore o altri diritti sul materiale. Un 
+     licenziante può avanzare richieste specifiche, come ad esempio
+     chiedere che ogni modifica al materiale venga contrassegnata o
+     descritta. Sebbene non sia richiesto dalle nostre licenze, sei
+     incoraggiato a rispettare queste richieste, ove ragionevole.
+	wiki.creativecommons.org/Considerations_for_licensors_and_licensees
+
+=======================================================================
+
+Licenza Pubblica Creative Commons Attribuzione-CondividiAlloStessoModo
+4.0 Internazionale
+
+Con l'esercizio di uno qualunque dei Diritti Concessi in Licenza (sotto
+definiti), Tu accetti e Ti obblighi a rispettare integralmente i
+termini e le condizioni della presente Licenza Pubblica Creative
+Commons Attribuzione-CondividiAlloStessoModo 4.0 Internazionale
+("Licenza Pubblica"). Laddove la presente Licenza Pubblica possa essere
+qualificata come un contratto, Ti sono attribuiti i Diritti Concessi in
+Licenza a fronte della Tua accettazione di questi termini e condizioni,
+e il Licenziante Ti attribuisce tali diritti a fronte dei benefici che
+egli riceve rendendo il Materiale Concesso in Licenza disponibile
+secondo questi termini e condizioni.
+
+Articolo 1 –- Definizioni.
+
+  a. Materiale Elaborato significa materiale oggetto di Diritti
+     d'Autore e Simili, che derivi o sia basato sul Materiale Concesso
+     in Licenza nel quale il Materiale Concesso in Licenza sia
+     tradotto, alterato, arrangiato, trasformato o altrimenti
+     modificato, in una maniera che richieda il permesso ai sensi dei
+     Diritti d'Autore e Simili detenuti dal Licenziante. Ai fini della
+     presente Licenza Pubblica, laddove il Materiale Concesso in
+     Licenza sia una composizione musicale, un'esecuzione musicale o
+     una registrazione di suoni, la sincronizzazione del Materiale
+     Concesso in Licenza con un'immagine in movimento costituisce
+     sempre Materiale Elaborato.
+
+  b. Licenza dell'Elaboratore significa la licenza che Tu concedi per i
+     tuoi Diritti d'Autore e Simili sui Tuoi contributi al Materiale
+     Elaborato, conformemente ai termini e alle condizioni della
+     presente Licenza Pubblica.
+
+  c. Licenza Compatibile con BY-SA significa una licenza elencata
+     all'indirizzo creativecommons.org/compatiblelicenses ed approvata
+     da Creative Commons come sostanzialmente equivalente alla presente
+     Licenza Pubblica.
+
+  d. Diritti d'Autore e Simili significa diritti d'autore e/o diritti
+     simili strettamente connessi al diritto d'autore, inclusi, fra gli
+     altri, l'esecuzione, la diffusione, la registrazione di suoni e il
+     Diritto Sui Generis sulle Banche Dati, comunque denominati o
+     classificati. Ai fini della presente Licenza Pubblica, i diritti
+     specificati all'interno degli Artt. 2(b)(1)-(2) non sono Diritti
+     d'Autore e Simili.
+
+  e. Misure Tecnologiche Efficaci significa quelle misure che, in
+     assenza di una specifica autorizzazione, non possono essere
+     aggirate secondo le norme che recepiscono gli obblighi previsti
+     dall'art. 11 del Trattato OMPI sul diritto d'autore adottato il
+     20 dicembre 1996 e/o simili accordi internazionali.
+
+  f. Eccezioni e Limitazioni significa qualunque eccezione e/o
+     limitazione ai Diritti D'Autore e Simili, inclusi "fair use" e
+     "fair dealing", che si applichi al Tuo utilizzo del Materiale
+     Concesso in Licenza.
+  
+  g. Elementi della Licenza significa gli attributi fondamentali
+     indicati nel nome di una Licenza Pubblica Creative Commons. Gli
+     Elementi della Licenza della presente Licenza Pubblica sono
+     Attribuzione e CondividiAlloStessoModo.
+
+  h. Materiale Concesso in Licenza significa qualsiasi opera artistica
+     o letteraria, banca dati, o altro materiale al quale il
+     Licenziante abbia applicato la presente Licenza Pubblica.
+
+  i. Diritti Concessi in Licenza significa tutti i diritti che sono
+     concessi a Te nel rispetto dei termini e delle condizioni della
+     presente Licenza Pubblica, limitatamente ai Diritti d'Autore e
+     Simili che si applicano al Tuo utilizzo del Materiale Concesso in
+     Licenza e che il Licenziante ha facoltà di licenziare.
+
+  j. Licenziante significa l'individuo, gli individui, l'ente o gli
+     enti che concede o concedono diritti secondo la presente Licenza
+     Pubblica.
+
+  k. Condividi/Condividere significa fornire materiale al pubblico con
+     ogni mezzo di comunicazione o formato che richieda
+     l'autorizzazione rispetto ai Diritti Concessi in Licenza, come la
+     riproduzione, l'esposizione ed esecuzione in pubblico, la
+     distribuzione, la divulgazione, la comunicazione al pubblico,
+     l'importazione e la messa a disposizione del pubblico del
+     materiale, anche con modalità che consentano di accedere al
+     materiale da un luogo e in un momento scelti individualmente dal
+     pubblico.
+
+  l. Diritto Sui Generis sulle Banche Dati significa quei diritti
+     ulteriori rispetto al diritto d'autore individuati dalla Direttiva
+     96/9/CE del Parlamento europeo e del Consiglio, dell'11 marzo 1996
+     e successive modificazioni, relativa alla tutela giuridica delle
+     banche di dati, nonché altri diritti sostanzialmente equivalenti
+     previsti ovunque nel mondo.
+
+  m. Tu significa l'individuo o l'ente che esercita i Diritti Concessi
+     in Licenza secondo la presente Licenza Pubblica.
+     Te/Tuo/Tua/Tuoi/Ti hanno un significato analogo.
+
+Articolo 2 –- Ambito di Applicazione.
+
+  a. Concessione della Licenza.
+
+       1. Nel rispetto dei termini e delle condizioni contenute nella
+          presente Licenza Pubblica, il Licenziante concede a Te una
+          licenza per tutto il mondo, gratuita, non sub-licenziabile,
+          non esclusiva e irrevocabile che Ti autorizza ad esercitare
+          i Diritti Concessi in Licenza sul Materiale Concesso in
+          Licenza per:
+
+            a. riprodurre e Condividere il Materiale Concesso in
+               Licenza, in tutto o in parte; e
+            
+            b. produrre, riprodurre e Condividere Materiale Elaborato.
+
+       2. Eccezioni e Limitazioni. Al fine di evitare dubbi, quando si
+          applicano delle Eccezioni o Limitazioni al Tuo utilizzo, la
+          presente Licenza Pubblica non si applica a Te e Tu non devi
+          rispettarne i termini e le condizioni.
+
+       3. Durata. La durata della presente Licenza Pubblica è
+          specificata all'interno dell'Art. 6(a).
+
+       4. Mezzi di comunicazione, supporti e formati; modifiche
+          tecniche consentite. Il Licenziante Ti autorizza a esercitare
+          i Diritti Concessi in Licenza con ogni mezzo di
+          comunicazione, su ogni supporto e in tutti i formati
+          esistenti e sviluppati in futuro, e ad apportare le modifiche
+          che si rendessero tecnicamente necessarie a tale scopo. Il
+          Licenziante rinuncia o si impegna a non far valere alcun
+          diritto o autorità per proibire a Te di effettuare le
+          modifiche che si rendessero tecnicamente necessarie per
+          l'esercizio dei Diritti Concessi in Licenza, incluse le
+          modifiche tecnicamente necessarie per aggirare Misure
+          Tecnologiche Efficaci. Ai fini della presente Licenza
+          Pubblica, apportare le modifiche autorizzate dal presente
+          Art. 2(a)(4) non costituisce in alcun caso Materiale
+          Elaborato.
+
+       5. Destinatari a valle.
+
+           a. Offerta dal Licenziante - Materiale Concesso in Licenza.
+              Ogni destinatario del Materiale Concesso in Licenza
+              riceve automaticamente un'offerta dal Licenziante ad
+              esercitare i Diritti Concessi in Licenza secondo i
+              termini e le condizioni della presente Licenza Pubblica.
+
+           b. Offerta aggiuntiva dal Licenziante - Materiale Elaborato.
+              Ogni destinatario del Materiale Elaborato da parte Tua
+              riceve automaticamente un'offerta dal Licenziante ad
+              esercitare i Diritti Concessi in Licenza sul Materiale
+              Elaborato secondo i termini e le condizioni della Licenza
+              dell'Elaboratore da Te applicata.
+
+           c. Divieto di restrizioni a valle. Tu non puoi offrire o
+              imporre termini e condizioni aggiuntive o differenti al,
+              né applicare Misure Tecnologiche Efficaci sul, Materiale
+              Concesso in Licenza che abbiano per effetto di
+              restringere l'esercizio dei Diritti Concessi in Licenza
+              da parte di qualsiasi destinatario del Materiale Concesso
+              in Licenza.
+
+       6. Assenza di avallo. La presente Licenza Pubblica non concede
+          né può essere interpretata in modo da concedere
+          un'autorizzazione ad affermare o fare intendere che Tu o il
+          Tuo utilizzo del Materiale Concesso in Licenza siate
+          connessi, sponsorizzati, avallati o riconosciuti come
+          ufficiali dal Licenziante o da altre parti designate a
+          vedersi riconosciuta l'attribuzione in accordo con quanto
+          previsto all'interno dell'Art. 3(a)(1)(A)(i).
+
+  b. Altri Diritti.
+
+       1. I diritti morali, come il diritto all'integrità, non sono
+          oggetto della presente Licenza Pubblica, né lo sono il
+          diritto all'immagine, il diritto alla riservatezza e/o altri
+          simili diritti della personalità; in ogni caso, per quanto
+          possibile, il Licenziante rinuncia o si impegna a non far
+          valere alcuno dei diritti sopraccitati detenuti dal
+          Licenziante, unicamente nei limiti della misura che sia
+          indispensabile per consentire a Te di esercitare i Diritti
+          Concessi in Licenza.
+
+       2. I diritti su brevetti e marchi non sono oggetto della
+          presente Licenza Pubblica.
+
+       3. Per quanto possibile, il Licenziante rinuncia al diritto
+          esclusivo di riscuotere da Te i compensi per l'esercizio dei
+          Diritti Concessi in Licenza, personalmente o per tramite di
+          un ente di gestione collettiva, relativi a qualsiasi sistema
+          di licenza volontario o rinunciabile per legge o
+          obbligatorio. In tutti gli altri casi, il Licenziante si
+          riserva espressamente il diritto esclusivo a riscuotere tali
+          compensi.
+
+Articolo 3 –- Condizioni della Licenza.
+
+Il Tuo esercizio dei Diritti Concessi in Licenza è espressamente
+soggetto alle seguenti condizioni.
+
+  a. Attribuzione.
+
+       1. Se Tu Condividi il Materiale Concesso in Licenza (anche in
+          forma modificata), Tu sei tenuto a:
+
+            a. riportare, se fornito dal Licenziante assieme al
+               Materiale Concesso in Licenza, ciò che segue:
+
+                 i. l'identificazione del creatore o dei creatori del
+                    Materiale Concesso in Licenza e delle terze parti
+                    designate a ricevere l'attribuzione, in qualsiasi
+                    maniera ragionevole che sia richiesta dal
+                    Licenziante (incluso lo pseudonimo, se designato);
+
+                ii. l'informativa sul diritto d'autore;
+
+               iii. l'informativa che si riferisce alla presente
+                    Licenza Pubblica; 
+
+                iv. l'informativa contenente esclusioni o limitazioni
+                    di responsabilità;
+
+                 v. l'Uniform Resource Identifier (URI) o il
+                    collegamento ipertestuale alla presente Licenza
+                    Pubblica nella misura in cui sia ragionevolmente
+                    possibile;
+
+            b. indicare se Tu hai modificato il Materiale Concesso in
+               Licenza e, nel caso, conservare un'indicazione di ogni
+               modifica precedente; e
+
+            c. indicare che il Materiale Concesso in Licenza è
+               rilasciato secondo i termini e le condizioni della
+               presente Licenza Pubblica, e includere il testo della,
+               oppure l'URI o il collegamento ipertestuale alla,
+               presente Licenza Pubblica.
+
+       2. Tu puoi adempiere alle condizioni dell'Art. 3(a)(1) in
+          qualsiasi maniera ragionevole, rispetto al mezzo di
+          comunicazione, al supporto, agli strumenti e al contesto
+          all'interno del quale Tu Condividi il Materiale Concesso in
+          Licenza. Ad esempio, può essere ragionevole soddisfare le
+          condizioni fornendo l'URI o il collegamento ipertestuale a
+          una risorsa che includa le informazioni richieste.
+
+       3. Su richiesta del Licenziante, nella misura in cui ciò sia
+          ragionevolmente praticabile, Tu devi rimuovere ognuna delle
+          informazioni richieste dall'Art. 3(a)(1)(A).
+
+  b. CondividiAlloStessoModo.
+
+    In aggiunta alle condizioni previste all'interno dell'Art. 3(a) di
+    cui sopra, se Tu Condividi Materiale Elaborato da Te prodotto, si
+    applicano anche le seguenti condizioni.
+
+        1. La Licenza dell'Elaboratore da Te applicata deve essere una
+           licenza Creative Commons, nella versione attuale o
+           successiva, dotata degli stessi Elementi della Licenza,
+           oppure una Licenza Compatibile con BY-SA.
+
+        2. Tu devi includere il testo della, oppure l'URI o il
+           collegamento ipertestuale alla, Licenza dell'Elaboratore da
+           Te applicata. Tu puoi adempiere a questa condizione in
+           qualsiasi maniera ragionevole possibile, rispetto al mezzo
+           di comunicazione, al supporto, agli strumenti e al contesto
+           all'interno del quale Tu Condividi il Materiale Elaborato.
+
+        3. Tu non puoi offrire o imporre termini e condizioni
+           aggiuntive o differenti al, né applicare Misure Tecnologiche
+           Efficaci sul Materiale Elaborato che abbiano per effetto di
+           restringere l'esercizio dei diritti concessi secondo i
+           termini e le condizioni della Licenza dell'Elaboratore da
+           Te applicata.
+
+Articolo 4 –- Diritto Sui Generis sulle Banche Dati.
+
+Laddove i Diritti Concessi in Licenza dovessero includere il Diritto
+Sui Generis sulle Banche Dati che si applichi al Tuo utilizzo del
+Materiale Concesso in Licenza:
+
+    a. al fine di evitare dubbi, l'Art. 2(a)(1) Ti concede il diritto
+       di estrarre, riutilizzare, riprodurre e Condividere tutti i
+       contenuti della banca dati o una loro parte sostanziale;
+
+    b. se Tu estrai tutti i contenuti della banca dati o una loro parte
+       sostanziale e li incorpori in una banca dati sulla quale Tu
+       detieni il Diritto Sui Generis sulle Banche Dati, allora la
+       banca dati sulla quale Tu detieni il Diritto Sui Generis sulle
+       Banche Dati (ma non i suoi singoli contenuti) costituisce
+       Materiale Elaborato, anche ai fini dell'Art. 3(b); e
+
+    c. Tu devi adempiere le condizioni dell'Art. 3(a) se Tu Condividi
+       tutti i contenuti della banca dati o una loro parte sostanziale.
+
+Al fine di evitare dubbi, il presente Art. 4 si aggiunge ai, e non
+sostituisce i, Tuoi obblighi ai sensi della presente Licenza Pubblica,
+laddove i Diritti Concessi in Licenza dovessero includere Diritti
+d'Autore e Simili.
+
+Articolo 5 –- Esclusione di Garanzie e Limitazione di Responsabilità.
+
+    a. Laddove il Licenziante non si sia separatamente impegnato
+       altrimenti, per quanto possibile il Licenziante offre il
+       Materiale Concesso in Licenza "così com'è" e "come disponibile",
+       e non fornisce alcuna dichiarazione o garanzia di qualsiasi tipo
+       con riguardo al Materiale Concesso in Licenza, sia essa espressa
+       o implicita, di fonte legale o di altro tipo. Questo comprende,
+       tra le altre, le garanzie relative al titolo, alla
+       commerciabilità, all'idoneità per un fine specifico, alla non
+       violazione di diritti di terzi, alla mancanza di difetti latenti
+       o di altro tipo, all'esattezza o alla presenza o assenza di
+       errori, siano o meno conosciuti o conoscibili. Laddove
+       l'esclusione di garanzie non sia consentita in tutto o in parte,
+       questa esclusione può non essere applicabile a Te.
+
+    b. Per quanto possibile, il Licenziante non sarà in alcun caso
+       responsabile nei Tuoi confronti ad alcun titolo (incluso, tra
+       gli altri, la negligenza) o altrimenti per qualunque danno
+       diretto, speciale, indiretto, incidentale, consequenziale,
+       punitivo, esemplare, o altra perdita, costo, spesa o danno
+       derivante dalla presente Licenza Pubblica o dall'utilizzo del
+       Materiale Concesso in Licenza, anche nel caso in cui il
+       Licenziante sia stato edotto sulla possibilità di tali perdite,
+       costi, spese o danni. Laddove una limitazione di responsabilità
+       non sia consentita in tutto o in parte, questa limitazione può
+       non essere applicabile a Te.
+
+    c. L'esclusione di garanzie e la limitazione di responsabilità di
+       cui sopra deve essere interpretata in maniera che, nei limiti
+       consentiti dalla legge applicabile, possa avvicinarsi quanto più
+       possibile ad una esclusione totale e a uno scarico di ogni
+       responsabilità.
+
+Articolo 6 –- Durata e Risoluzione.
+
+    a. La presente Licenza Pubblica è valida per tutta la durata dei
+       Diritti d'Autore e Simili oggetto della presente Licenza
+       Pubblica. Tuttavia, in caso di Tuo mancato adempimento dei
+       termini e delle condizioni della presente Licenza Pubblica, i
+       diritti che Ti sono concessi dalla presente Licenza Pubblica
+       cesseranno automaticamente.
+
+    b. Quando il Tuo diritto ad utilizzare il Materiale Concesso in
+       Licenza sia cessato secondo quanto previsto dall'Art. 6(a), tale
+       diritto è reintegrato:
+
+        1. automaticamente a partire dal momento in cui il mancato
+           adempimento è sanato, purché ciò si verifichi entro trenta
+           giorni dal momento in cui Tu sei venuto a conoscenza del
+           mancato adempimento; oppure
+
+        2. su espressa reintegrazione da parte del Licenziante.
+
+    Al fine di evitare dubbi, il presente Art. 6(b) non pregiudica
+    alcun diritto di cui il Licenziante sia titolare al fine di
+    ottenere rimedi a fronte della violazione da parte Tua della
+    presente Licenza Pubblica.
+
+        c. Al fine di evitare dubbi, il Licenziante si riserva il
+           diritto di rilasciare il Materiale Concesso in Licenza sulla
+           base di termini e condizioni separati da quelli della
+           presente Licenza Pubblica o di cessare la distribuzione del
+           Materiale Concesso in Licenza in qualsiasi momento; in ogni
+           caso, tali decisioni non comporteranno la risoluzione della
+           presente Licenza Pubblica.
+
+        d. Gli Artt. 1, 5, 6, 7 e 8 rimangono validi in caso di
+           risoluzione della presente Licenza.
+
+Articolo 7 –- Altri Termini e Condizioni.
+
+    a. Il Licenziante non sarà vincolato ad alcun altro termine o
+       condizione aggiuntivo o differente che provenga da Te, salvo che
+       ciò venga espressamente consentito.
+
+    b. Ogni intesa, patto o accordo aggiuntivo riguardo al Materiale
+       Concesso in Licenza non contenuto nella presente è da
+       considerarsi separato ed indipendente dai termini e dalle
+       condizioni della presente Licenza Pubblica.
+
+Articolo 8 –- Interpretazione.
+
+    a. Al fine di evitare dubbi, la presente Licenza Pubblica non
+       intende, né deve essere interpretata in modo da ridurre,
+       limitare, restringere o condizionare alcun utilizzo del
+       Materiale Concesso in Licenza che sia lecito anche in assenza di
+       autorizzazione ai sensi della presente Licenza Pubblica.
+
+    b. Nei limiti consentiti dalla legge applicabile, qualora una o più
+       disposizioni della presente Licenza Pubblica siano giudicate
+       invalide o inefficaci, saranno da intendersi rettificate nei
+       limiti della misura che sia indispensabile per renderle valide
+       ed efficaci. Se una o più disposizioni non possono essere
+       rettificate, dovranno essere eliminate dalla presente Licenza
+       Pubblica senza comportare l'invalidità o l'inefficacia dei
+       restanti termini e condizioni.
+
+    c. In nessun caso i termini e le condizioni di cui alla presente
+       Licenza Pubblica possono essere rinunciati né alcun mancato
+       adempimento può essere consentito, salvo che tale rinuncia o
+       consenso venga espressamente autorizzato dal Licenziante.
+
+    d. Nessuna parte della presente Licenza Pubblica può in alcun modo
+       costituire o essere interpretata come una limitazione o una
+       rinuncia a qualsiasi privilegio o immunità che possa applicarsi
+       al Licenziante o a Te, inclusi quelli derivanti dai procedimenti
+       giudiziari di qualsivoglia giurisdizione o autorità.
+
+
+
+=======================================================================
+
+Creative Commons non è una delle parti rispetto alle sue licenze
+pubbliche. Ciò nonostante, Creative Commons può decidere di applicare
+una delle sue licenze pubbliche a materiale di sua pubblicazione, nel
+qual caso sarà considerata, relativamente ad esso, il "Licenziante".
+Il testo delle licenze pubbliche Creative Commons è dedicato al
+pubblico dominio secondo i termini della 
+creativecommons.org/publicdomain/zero/1.0/legalcode.it
+Donazione al Pubblico Dominio CC0. Salvo che per il solo scopo di
+indicare che il materiale è rilasciato secondo i termini e le
+condizioni di una licenza pubblica Creative Commons o come altrimenti
+consentito dalle policy di Creative Commons consultabili all'indirizzo
+creativecommons.org/policies, Creative Commons non autorizza l'utilizzo
+del marchio "Creative Commons" o di qualsiasi altro marchio o logo di
+Creative Commons senza il suo preventivo consenso scritto, incluso,
+fra gli altri, quello in connessione con qualsiasi modifica non
+autorizzata alle sue licenze pubbliche o con qualsiasi altra intesa,
+patto o accordo circa l'utilizzo del materiale concesso in licenza.
+Al fine di evitare dubbi, è inteso che questo paragrafo non fa parte
+delle licenze pubbliche.
+
+Creative Commons può essere contattata al sito creativecommons.org.

--- a/it/README.md
+++ b/it/README.md
@@ -14,11 +14,11 @@ Il modo più semplice per trovare la giusta licenza CC per il tuo progetto è il
 
 Qui vi presento tre tipi di licenze CC:
 
-* [Creative Commons Attribuzione 4.0 Internazionale](#cc-attribution-40-international)
+* [Creative Commons Attribuzione 4.0 Internazionale](#cc-attribuzione-40-internazionale)
 
-* [Creative Commons Attribuzione - Condividi allo stesso modo 4.0 Internazionale](#cc-attribution-sharealike-40-international)
+* [Creative Commons Attribuzione - Condividi allo stesso modo 4.0 Internazionale](#cc-attribuzione---condividi-allo-stesso-modo-40-internazionale)
 
-* [Creative Commons Attribuzione - Non commerciale - Condividi allo stesso modo 4.0 Internazionale](#cc-attribution-noncommercial-sharealike-40-international)
+* [Creative Commons Attribuzione - Non commerciale - Condividi allo stesso modo 4.0 Internazionale](#cc-attribuzione---non-commerciale---condividi-allo-stesso-modo-40-internazionale)
 
 Ulteriori informazioni sulle licenze ed i testi delle licenze formattate in ```plain text``` possono essere trovate sul sito https://choosealicense.com/.
 

--- a/it/README.md
+++ b/it/README.md
@@ -1,39 +1,31 @@
-# Creative Commons Licenses for GitHub Projects
+# Licenze Creative Commons Licenses per progetti GitHub
 
-[![German](https://img.shields.io/badge/translation-DE-red)](de/)
-[![Spanish](https://img.shields.io/badge/translation-ES-red)](es/)
-[![Italian](https://img.shields.io/badge/translation-IT-red)](it/)
+[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/../../)
 
-In this repo you can find easy ways for applying Creative Commons Licenses on
-Github repositories through Markdown language.
+In questo repo troverai dei modi facili di applicare le licenze Creative Commons ai repository attraverso il linguaggio Markdown.
 
-> **WARNING:**
-> You shouldn't use Creative Commons licenses for software.
-> Use Free Software Licenses for that kind of repositories, like GPL, BSD, etc.
-> Creative Commons Licenses are meant for intellectual works only.
+> **ATTENZIONE:**
+> Tu non dovrai usare le licenze Creative Commons per i programmi.
+> Usa le licenze Free Software per questi tipi di repository, come ad esempio GPL, BSD, ecc.
+> Le licenze Creative Commons sono pensate solo per le opere intellettuali.
 
+Il modo più semplice per trovare la giusta licenza CC per il tuo progetto è il
+[sito Creative Commons](https://creativecommons.org/choose/?lang=it).
 
-The easiest way for finding the right CC License for your project is the
-[Creative Commons website](https://creativecommons.org/choose/).
-
-Here we present two types of CC Licenses:
+Qui vi presento due tipi di licenze CC:
 
 * [Creative Commons Attribution 4.0 International](#cc-attribution-40-international)
 
 * [Creative Commons Attribution-ShareAlike 4.0 International](#cc-attribution-sharealike-40-international)
 
-More information about licenses, and plain-text formatted licenses texts can be
-found on https://choosealicense.com/.
+Ulteriori informazioni sulle licenze ed i testi delle licenze formattate in ```plain text``` possono essere trovate sul sito https://choosealicense.com/.
 
-If you want to download vectorized version of Creative Commons images and other
-related stuff, please visit https://creativecommons.org/about/downloads/.
+Se tu vuoi scaricare una versione vettoriale delle immagini Creative Commons ed altre cose relative, visita il sito https://creativecommons.org/about/downloads/.
 
 
 ## CC Attribution 4.0 International
 
-To add a CC BY License to your project, just add the following to your
-`README.md`. You should also copy the corresponding [license text
-file](LICENSE-CC-BY) and rename it to `LICENSE`.
+Per aggiungere una licenza CC BY al tuo progetto, ti basta aggiunge il seguente testo al tuo file `README.md`. Dovrai inoltre copiare il corrispondente [file di testo della licenza](LICENSE-CC-BY) e rinominarlo in `LICENSE`.
 
 ```markdown
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
@@ -62,9 +54,7 @@ This work is licensed under a
 
 ## CC Attribution-ShareAlike 4.0 International
 
-To add a CC BY-SA License to your project, just add the following to your
-`README.md`. You should also copy the corresponding [license text
-file](LICENSE-CC-BY-SA) and rename it to `LICENSE`.
+Per aggiungere una licenza CC BY-SA al tuo progetto, ti basterà aggiungere il seguente testo al tuo file `README.md`. Dovrai inoltre copiare il corrispondente [file di testo della licenza](LICENSE-CC-BY-SA) e rinominarlo in `LICENSE`.
 
 ```markdown
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]

--- a/it/README.md
+++ b/it/README.md
@@ -12,70 +12,99 @@ In questo repo troverai dei modi facili di applicare le licenze Creative Commons
 Il modo più semplice per trovare la giusta licenza CC per il tuo progetto è il
 [sito Creative Commons](https://creativecommons.org/choose/?lang=it).
 
-Qui vi presento due tipi di licenze CC:
+Qui vi presento tre tipi di licenze CC:
 
-* [Creative Commons Attribution 4.0 International](#cc-attribution-40-international)
+* [Creative Commons Attribuzione 4.0 Internazionale](#cc-attribution-40-international)
 
-* [Creative Commons Attribution-ShareAlike 4.0 International](#cc-attribution-sharealike-40-international)
+* [Creative Commons Attribuzione - Condividi allo stesso modo 4.0 Internazionale](#cc-attribution-sharealike-40-international)
+
+* [Creative Commons Attribuzione - Non commerciale - Condividi allo stesso modo 4.0 Internazionale](#cc-attribution-noncommercial-sharealike-40-international)
 
 Ulteriori informazioni sulle licenze ed i testi delle licenze formattate in ```plain text``` possono essere trovate sul sito https://choosealicense.com/.
 
 Se tu vuoi scaricare una versione vettoriale delle immagini Creative Commons ed altre cose relative, visita il sito https://creativecommons.org/about/downloads/.
 
 
-## CC Attribution 4.0 International
+## CC Attribuzione 4.0 Internazionale
 
 Per aggiungere una licenza CC BY al tuo progetto, ti basta aggiunge il seguente testo al tuo file `README.md`. Dovrai inoltre copiare il corrispondente [file di testo della licenza](LICENSE-CC-BY) e rinominarlo in `LICENSE`.
 
 ```markdown
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-This work is licensed under a
-[Creative Commons Attribution 4.0 International License][cc-by].
+Questa opera è sotto 
+[Licenza Creative Commons Attribuzione 4.0 Internazionale][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 
-[cc-by]: http://creativecommons.org/licenses/by/4.0/
+[cc-by]: http://creativecommons.org/licenses/by/4.0/deed.it
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
 ```
 
 Shield: [![CC BY 4.0][cc-by-shield]][cc-by]
 
-This work is licensed under a
-[Creative Commons Attribution 4.0 International License][cc-by].
+Questa opera è sotto
+[Licenza Creative Commons Attribuzione 4.0 Internazionale][cc-by].
 
 [![CC BY 4.0][cc-by-image]][cc-by]
 
-[cc-by]: http://creativecommons.org/licenses/by/4.0/
+[cc-by]: http://creativecommons.org/licenses/by/4.0/deed.it
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
 
 
-## CC Attribution-ShareAlike 4.0 International
+## CC Attribuzione - Condividi allo stesso modo 4.0 Internazionale
 
 Per aggiungere una licenza CC BY-SA al tuo progetto, ti basterà aggiungere il seguente testo al tuo file `README.md`. Dovrai inoltre copiare il corrispondente [file di testo della licenza](LICENSE-CC-BY-SA) e rinominarlo in `LICENSE`.
 
 ```markdown
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-This work is licensed under a
-[Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa].
+Questa opera è sotto 
+[Licenza Creative Commons Attribuzione - Condividi allo stesso modo 4.0 Internazionale][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 
-[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/deed.it
 [cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
 [cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
 ```
 
 Shield: [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-This work is licensed under a [Creative Commons Attribution-ShareAlike 4.0
-International License][cc-by-sa].
+Questa opera è sotto [Licenza Creative Commons Attribuzione - Condividi allo stesso modo 4.0
+Internazionale][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 
-[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/deed.it
 [cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
 [cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
+
+## CC Attribuzione - Non commerciale - Condividi allo stesso modo 4.0 Internazionale
+
+Per aggiungere una licenza CC BY-NC-SA  al tuo progetto, ti basterà aggiungere il seguente testo al tuo file `README.md`.  Dovrai inoltre copiare il corrispondente [file di testo della licenza](LICENSE-CC-BY-NC-SA) e rinominarlo in `LICENSE`.
+
+```markdown
+Shield: [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
+
+Questa opera è sotto 
+[Licenza Creative Commons Attribuzione - Non commerciale - Condividi allo stesso modo 4.0 Internazionale][cc-by-nc-sa].
+
+[![CC BY-NC-SA 4.0][cc-by-nc-sa-image]][cc-by-nc-sa]
+
+[cc-by-nc-sa]: http://creativecommons.org/licenses/by-nc-sa/4.0/deed.it
+[cc-by-nc-sa-image]: https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png
+[cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg
+```
+
+Shield: [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
+
+Questa opera è sotto [Licenza Attribuzione - Non commerciale - Condividi allo stesso modo 4.0 Internazionale][cc-by-nc-sa].
+
+[![CC BY-NC-SA 4.0][cc-by-nc-sa-image]][cc-by-nc-sa]
+
+[cc-by-nc-sa]: http://creativecommons.org/licenses/by-nc-sa/4.0/deed.it
+[cc-by-nc-sa-image]: https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png
+[cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg


### PR DESCRIPTION
Added a new it folder containing a README.md file that is a translation of the English README.md.
Added the Italian version of the license texts (convert the html version of the creative commons website).
Added a badge on the main README.md pointing to the Italian translation folder.
Added a badge on it/README.md pointing to the main README.md.

I hope the formatting of the plain text of the licence is pretty good :) If not, I try to correct it

Thanks

Fixes #13 