### PR TITLE
Add Portuguese versions of the licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Italian](https://img.shields.io/badge/translation-IT-red)](it/)
 [![Polish](https://img.shields.io/badge/translation-PL-red)](pl/)
 [![Spanish](https://img.shields.io/badge/translation-ES-red)](es/)
+[![Portuguese](https://img.shields.io/badge/translation-PT-red)](pt/)
 
 In this repo you can find easy ways for applying Creative Commons Licenses on
 Github repositories through Markdown language.

--- a/pt/LICENSE-CC-BY
+++ b/pt/LICENSE-CC-BY
@@ -1,0 +1,424 @@
+Atribuição 4.0 Internacional
+
+=======================================================================
+
+A organização Creative Commons (“Creative Commons”) não é um
+escritório de advocacia e não presta serviços jurídicos ou
+aconselhamento jurídico. A distribuição das licenças públicas Creative
+Commons não estabelece uma relação advogado-cliente ou outra relação.
+A Creative Commons disponibiliza as suas licenças e informação
+relacionada “no estado em que se encontram” (“as-is”). A Creative
+Commons não oferece garantias relativamente às suas licenças, a
+qualquer material licenciado sob os seus termos e condições, ou a
+qualquer informação relacionada. A Creative Commons exonera-se, da
+forma mais ampla possível, de qualquer responsabilidade por danos
+decorrentes da sua utilização.
+
+Utilizando as Licenças Públicas Creative Commons
+
+As licenças públicas Creative Commons oferecem um conjunto padrão de
+termos e condições que criadores e outros detentores de direitos podem
+utilizar para compartilhar obras originais de autor, outros materiais
+sujeitos a direito de autor e direitos conexos, e certos outros
+direitos especificados na licença pública abaixo. As considerações a
+seguir são apenas para fins de informação, não são exaustivas e não
+fazem parte de nossas licenças.
+
+    Considerações para licenciantes: As nossas licenças públicas são
+    destinadas a utilização por aqueles que tenham autorização para
+    conceder permissão pública para a utilização de material de
+    maneiras que seriam, caso contrário, restringidas pelo direito de
+    autor e direitos conexos, e certos outros direitos. As nossas
+    licenças são irrevogáveis. Os licenciantes devem ler e entender os
+    termos e condições da licença escolhida antes de aplicá-la. Os
+    licenciantes devem assegurar todos os direitos necessários antes
+    de aplicar as nossas licenças, de modo a que o público possa
+    reutilizar o material conforme esperado. Os licenciantes devem
+    identificar claramente qualquer material não sujeito à licença.
+    Isso inclui outros materiais licenciados sob CC, ou materiais
+    utilizados sob uma exceção ou limitação ao direito de autor e
+    direitos conexos. Mais considerações para licenciantes:
+    wiki.creativecommons.org/Considerations_for_licensors.
+
+    Considerações para o público: Ao utilizar uma das nossas licenças
+    públicas, o licenciante concede ao público permissão para utilizar
+    o material licenciado sob termos e condições especificados. Se a
+    permissão do licenciante não for necessária por qualquer razão –
+    por exemplo, por ser aplicável qualquer exceção ou limitação ao
+    direito de autor e direitos conexos -- então essa utilização não é
+    regida pela licença. As nossas licenças concedem somente
+    permissões relativas a direito de autor e direitos conexos, e
+    certos outros direitos que um licenciante tenha autoridade para
+    conceder. A utilização do material licenciado pode ainda ser
+    restringida por outras razões, incluindo porque terceiros têm
+    direito de autor e direitos conexos, ou outros direitos sobre o
+    material. Um licenciante pode fazer pedidos especiais, como
+    solicitar que todas as alterações sejam marcadas ou descritas.
+    Embora não exigido pelas nossas licenças, é recomendado que você
+    respeite esses pedidos quando razoáveis. Mais considerações para o
+    público: wiki.creativecommons.org/Considerations_for_licensees.
+
+=======================================================================
+
+Licença Pública Creative Commons Atribuição 4.0 Internacional
+
+Ao exercer os Direitos Licenciados (definidos abaixo), Você aceita e
+concorda estar sujeito aos termos e condições desta Licença Pública
+Creative Commons Atribuição 4.0 Internacional ("Licença Pública"). Na
+medida em que esta Licença Pública possa ser interpretada como um
+contrato, Você recebe os Direitos Licenciados em contrapartida pela
+Sua aceitação destes termos e condições, e o Licenciante concede-Lhe
+tais direitos em contrapartida pelos benefícios que o Licenciante
+recebe por disponibilizar o Material Licenciado sob estes termos e
+condições.
+
+Cláusula 1 -- Definições.
+
+  a. Material Adaptado significa material sujeito a Direito de Autor e
+     Direitos Similares que é derivado de ou baseado no Material
+     Licenciado e no qual o Material Licenciado é traduzido, alterado,
+     arranjado, transformado, ou de outra forma modificado de uma
+     maneira que requeira permissão com base no Direito de Autor e
+     Direitos Similares detidos pelo Licenciante. Para os fins desta
+     Licença Pública, quando o Material Licenciado seja uma obra
+     musical, performance, ou fonograma, é sempre produzido Material
+     Adaptado quando o Material Licenciado é sincronizado em relação
+     temporal com uma imagem em movimento.
+
+  b. Licença do Adaptador significa a licença que Você aplica ao Seu
+     Direito de Autor e Direitos Similares nas Suas contribuições ao
+     Material Adaptado de acordo com os termos e condições desta
+     Licença Pública.
+
+  c. Direito de Autor e Direitos Similares significa direito de autor
+     e/ou direitos similares estreitamente relacionados com o direito
+     de autor, incluindo, mas não se limitando a, direitos de
+     execução, radiodifusão, fixação de sons, e Direitos Sui Generis
+     sobre Bases de Dados, independentemente de como sejam
+     classificados ou categorizados. Para os fins desta Licença
+     Pública, os direitos especificados na Cláusula 2(b)(1)-(2) não
+     são Direito de Autor e Direitos Similares.
+
+  d. Medidas Eficazes de Caráter Tecnológico significam aquelas
+     medidas que, na ausência de direito para tanto, não podem ser
+     contornadas em jurisdições cumprindo obrigações sob o Artigo 11
+     do Tratado da OMPI de Direito de Autor adotado em 20 de dezembro
+     de 1996, e/ou acordos internacionais similares.
+
+  e. Exceções e Limitações significam utilização justa (“fair use”),
+     tratamento justo (“fair dealing”), e/ou qualquer outra exceção ou
+     limitação ao Direito de Autor e Direitos Similares que se aplique
+     à Sua utilização do Material Licenciado.
+
+  f. Material Licenciado significa o trabalho artístico ou literário,
+     base de dados, ou outro material ao qual o Licenciante aplicou
+     esta Licença Pública.
+
+  g. Direitos Licenciados significam os direitos concedidos a Você
+     sujeitos aos termos e condições desta Licença Pública, que são
+     limitados a todos os Direitos de Autor e Direitos Similares que
+     se apliquem à Sua utilização do Material Licenciado e que o
+     Licenciante tem o direito de licenciar.
+
+  h. Licenciante significa o(s) indivíduo(s) ou entidade(s) concedendo
+     direitos sob esta Licença Pública.
+
+  i. Compartilhar significa fornecer material ao público por qualquer
+     meio ou processo que requeira permissão sob os Direitos
+     Licenciados, como reprodução, exibição pública, execução pública,
+     distribuição, disseminação, comunicação ou importação, e
+     disponibilizar material ao público, incluindo por vias pelas
+     quais os membros do público possam ter acesso ao material a
+     partir de um local e no momento individualmente escolhidos por
+     eles.
+
+  j. Direitos Sui Generis sobre Bases de Dados significam outros
+     direitos, que não o direito de autor e direitos conexos,
+     resultantes da Diretiva 96/9/EC do Parlamento Europeu e do
+     Conselho de 11 de Março de 1996 sobre a proteção legal de bases
+     de dados, conforme emendada e/ou sucedida, bem como outros
+     direitos essencialmente equivalentes em qualquer lugar do mundo.
+
+  k. Você significa o indivíduo ou entidade que exerce os Direitos
+     Licenciados sob esta Licença Pública. Lhe, Seu, Sua e Suas têm um
+     significado correspondente.
+
+Cláusula 2 -- Âmbito.
+
+  a. Concessão da licença.
+
+       1. De acordo com os termos e condições desta Licença Pública, o
+          Licenciante concede-Lhe, pelo presente, uma licença mundial,
+          isenta de royalties, não sublicenciável, não exclusiva, e
+          irrevogável para exercer os Direitos Licenciados sobre o
+          Material Licenciado para:
+
+            a. reproduzir e Compartilhar o Material Licenciado, no
+               todo ou em parte; e
+
+            b. produzir, reproduzir, e Compartilhar Material Adaptado.
+
+       2. Exceções e Limitações. Para evitar dúvidas, quando Exceções
+          e Limitações sejam aplicáveis à Sua utilização, esta Licença
+          Pública não se aplica, e Você não precisa de cumprir com os
+          seus termos e condições.
+
+       3. Termo. O termo desta Licença Pública está especificado na
+          Cláusula 6(a).
+
+       4. Meios/suportes e formatos; modificações técnicas permitidas.
+          O Licenciante autoriza Você a exercer os Direitos
+          Licenciados em todos os meios/suportes e formatos conhecidos
+          agora ou criados posteriormente, e a fazer as modificações
+          técnicas necessárias para tanto. O Licenciante cede e/ou
+          concorda em não reivindicar nenhum direito que proíba Você
+          de fazer modificações técnicas necessárias ao exercício dos
+          Direitos Licenciados, incluindo modificações técnicas
+          necessárias para contornar Medidas Eficazes de Caráter
+          Tecnológico. Para os fins desta Licença Pública, fazer
+          simplesmente modificações autorizadas por esta Cláusula 2(a)
+          (4) nunca produz Material Adaptado.
+
+       5. Receptores subsequentes.
+
+            a. Oferta pelo Licenciante -- Material Licenciado. Cada
+               receptor do Material Licenciado recebe automaticamente
+               uma oferta do Licenciante para exercer os Direitos
+               Licenciados sob os termos e condições desta Licença
+               Pública.
+
+            b. Sem restrições subsequentes. Você não pode propor ou
+               impor quaisquer termos ou condições, adicionais ou
+               diferentes, ou aplicar quaisquer Medidas Eficazes de
+               Caráter Tecnológico, sobre o Material Licenciado, se
+               tal restringir o exercício dos Direitos Licenciados por
+               qualquer receptor do Material Licenciado.
+
+       6. Sem endosso. Nada nesta Licença Pública constitui ou pode
+          ser entendido como uma permissão para afirmar ou sugerir que
+          Você, ou que a Sua utilização do Material Licenciado, é
+          conectado ao, patrocinado ou endossado pelo, ou tem status
+          oficial concedido pelo, Licenciante ou terceiros designados
+          para receber atribuição como previsto na Cláusula 3(a)(1)(A)
+          (i).
+
+  b. Outros direitos.
+
+       1. Direitos morais, como o direito à integridade, não são
+          licenciados por esta Licença Pública, nem o são os direitos
+          de imagem, privacidade, e/ou outros direitos de
+          personalidade similares; contudo, na medida do possível, o
+          Licenciante renuncia e/ou concorda não exercer quaisquer
+          desses direitos detidos pelo Licenciante, na medida
+          necessária para permitir que Você exerça os Direitos
+          Licenciados, mas não de outra forma.
+
+       2. Direitos de patente e marcas não se encontram licenciados
+          sob esta Licença Pública.
+
+       3. Na medida do possível, o Licenciante renuncia a qualquer
+          direito de cobrar-Lhe royalties pelo exercício dos Direitos
+          Licenciados, quer diretamente quer por meio de uma entidade
+          de gestão coletiva, sob qualquer regime de licenciamento
+          voluntário ou legal, disponível ou compulsório. Em todos os
+          outros casos, o Licenciante reserva expressamente o direito
+          de arrecadar tais royalties.
+
+
+Cláusula 3 -- Condições da Licença.
+
+O Seu exercício dos Direitos Licenciados fica expressamente sujeito às
+condições seguintes.
+
+  a. Atribuição.
+
+       1. Se Você Compartilhar o Material Licenciado (incluindo sob
+          uma forma modificada), Você deve:
+
+            a. manter o seguinte, se for fornecido pelo Licenciante
+               com o Material Licenciado:
+
+                 i. identificação do(s) criador(es) do Material
+                    Licenciado e quaisquer outros designados para
+                    receber atribuição, de qualquer forma razoável
+                    solicitada pelo Licenciante (incluindo por
+                    pseudónimo, se designado);
+
+                ii. um aviso de direito de autor e direitos conexos;
+
+               iii. um aviso que se refere a esta Licença Pública;
+
+                iv. um aviso que se refere à exclusão de garantias;
+
+                 v. um URI ou um hyperlink para o Material Licenciado
+                    na medida razoavelmente exequível;
+
+            b. indicar se Você modificou o Material Licenciado e
+               manter uma indicação de quaisquer modificações prévias;
+               e
+
+            c. indicar que o Material Licenciado é licenciado com esta
+               Licença Pública, e incluir o texto de, ou o URI ou o
+               hyperlink para, esta Licença Pública.
+
+       2. Você pode satisfazer as condições da Cláusula 3(a)(1) de
+          qualquer forma razoável, tendo em conta o suporte, os meios
+          e o contexto no qual Você Compartilhar o Material
+          Licenciado. Por exemplo, pode ser razoável satisfazer as
+          condições por via do fornecimento de um URI ou de um
+          hyperlink para um recurso que inclui a informação exigida.
+
+       3. Se solicitado pelo Licenciante, Você deve remover qualquer
+          parte da informação exigida pela Cláusula 3(a)(1)(A) na
+          medida razoavelmente exequível.
+
+       4. Se Você Compartilhar Material Adaptado produzido por Você, a
+          Licença do Adaptador que Você aplicar não deve impedir os
+          receptores do Material Adaptado de cumprirem com esta
+          Licença Pública.
+
+
+Cláusula 4 -- Direitos Sui Generis sobre Bases de Dados.
+
+Quando os Direitos Licenciados incluam Direitos Sui Generis sobre
+Bases de Dados que se apliquem à Sua utilização do Material
+Licenciado:
+
+  a. para evitar dúvidas, a Cláusula 2(a)(1) concede-Lhe o direito de
+     extrair, reutilizar, reproduzir e Compartilhar a totalidade ou
+     uma parte substancial dos conteúdos da base de dados;
+
+  b. se Você incluir a totalidade ou uma parte substancial dos
+     conteúdos da base de dados numa base de dados em relação à qual
+     Você tenha Direitos Sui Generis sobre Bases de Dados, então a
+     base de dados em relação à qual Você tenha Direitos Sui Generis
+     sobre Bases de Dados (mas não os seus conteúdos individuais) é
+     Material Adaptado; e
+
+  c. Você deve cumprir com as condições da Cláusula 3(a) se Você
+     Compartilhar a totalidade ou uma parte substancial dos conteúdos
+     da base de dados.
+
+Para evitar dúvidas, esta Cláusula 4 suplementa e não substitui as
+Suas obrigações sob esta Licença Pública, quando os Direitos
+Licenciados incluam outro Direito de Autor e Direitos Similares.
+
+Cláusula 5 -- Exclusão de Garantias e Limitação de Responsabilidade.
+
+  a. SALVO SE O LICENCIANTE FIZER SEPARADAMENTE UMA ASSUNÇÃO EM
+     SENTIDO CONTRÁRIO, NA MEDIDA DO POSSÍVEL, O LICENCIANTE
+     DISPONIBILIZA O MATERIAL LICENCIADO “NO ESTADO EM QUE SE
+     ENCONTRA” (“AS-IS”) E “COMO DISPONÍVEL” (“AS-AVAILABLE”), E NÃO
+     FAZ REPRESENTAÇÕES OU PRESTA GARANTIAS DE QUALQUER TIPO
+     RELATIVAMENTE AO MATERIAL LICENCIADO, QUER SEJAM EXPRESSAS,
+     IMPLÍCITAS, LEGAIS OU OUTRAS. ISTO INCLUI, MAS NÃO SE LIMITA A,
+     GARANTIAS QUANTO À TITULARIDADE DE DIREITOS, POTENCIAL DE
+     COMERCIALIZAÇÃO, ADEQUAÇÃO A UM FIM ESPECÍFICO, NÃO VIOLAÇÃO DE
+     DIREITOS, AUSÊNCIA DE DEFEITOS LATENTES OU OUTROS DEFEITOS,
+     EXATIDÃO, OU EXISTÊNCIA OU AUSÊNCIA DE ERROS, QUER SEJAM OU NÃO
+     CONHECIDOS OU DETETÁVEIS. QUANDO AS EXCLUSÕES DE GARANTIAS NÃO
+     SEJAM PERMITIDAS, NA ÍNTEGRA OU EM PARTE, ESTA EXCLUSÃO PODERÁ
+     NÃO APLICAR-SE A VOCÊ.
+
+  b. NA MEDIDA DO POSSÍVEL, EM NENHUM CASO SERÁ O LICENCIANTE
+     RESPONSÁVEL PARA COM VOCÊ, COM BASE EM NENHUM ARGUMENTO JURÍDICO
+     (INCLUINDO, MAS NÃO SE LIMITANDO A, NEGLIGÊNCIA) OU A OUTRO
+     TÍTULO, POR QUAISQUER PERDAS, CUSTOS, DESPESAS OU DANOS, DIRETOS,
+     ESPECIAIS, INDIRETOS, INCIDENTAIS, CONSEQUENCIAIS, PUNITIVOS,
+     EXEMPLARES OU OUTROS, RESULTANTES DESTA LICENÇA PÚBLICA OU DA
+     UTILIZAÇÃO DO MATERIAL LICENCIADO, AINDA QUE O LICENCIANTE TENHA
+     SIDO ADVERTIDO DA POSSIBILIDADE DESSAS PERDAS, CUSTOS, DESPESAS
+     OU DANOS. QUANDO A LIMITAÇÃO DE RESPONSABILIDADE NÃO SEJA
+     PERMITIDA, NA ÍNTEGRA OU EM PARTE, ESTA LIMITAÇÃO PODERÁ NÃO
+     APLICAR-SE A VOCÊ.
+
+  c. A exclusão de garantias e a limitação de responsabilidade acima
+     previstas devem ser interpretadas de uma forma que, na medida do
+     possível, mais se aproxime de uma absoluta exclusão de, e
+     renúncia a, toda e qualquer responsabilidade.
+
+
+Cláusula 6 -- Termo e Cessação.
+
+  a. Esta Licença Pública aplica-se durante o termo do Direito de
+     Autor e Direitos Similares aqui licenciados. No entanto, se Você
+     não cumprir com esta Licença Pública, então os Seus direitos sob
+     esta Licença Pública cessarão automaticamente.
+
+  b. Quando o Seu direito de utilizar o Material Licenciado tenha
+     cessado nos termos da Cláusula 6(a), será restabelecido:
+
+       1. automaticamente a partir da data em que a violação seja
+          sanada, desde que seja sanada dentro de 30 dias a contar da
+          Sua descoberta da violação; ou
+
+       2. com o expresso restabelecimento pelo Licenciante.
+
+     Para evitar dúvidas, esta Cláusula 6(b) não afeta qualquer
+     direito que o Licenciante possa ter de obter reparação e medidas
+     legais cabíveis pelas Suas violações desta Licença Pública.
+
+  c. Para evitar dúvidas, o Licenciante também poderá disponibilizar o
+     Material Licenciado sob termos ou condições separados ou parar a
+     distribuição do Material Licenciado a qualquer momento; no
+     entanto, tal não cessará esta Licença Pública.
+
+  d. As Cláusulas 1, 5, 6, 7, e 8 continuarão em vigor após a cessação
+     desta Licença Pública.
+
+
+Cláusula 7 -- Outros Termos e Condições.
+
+  a. O Licenciante não estará vinculado a quaisquer termos ou
+     condições, adicionais ou diferentes, comunicados por Você, salvo
+     se expressamente acordado.
+
+  b. Quaisquer pactos, entendimentos ou acordos relativamente ao
+     Material Licenciado não indicados aqui são separados e
+     independentes dos termos e condições desta Licença Pública.
+
+Cláusula 8 -- Interpretação.
+
+  a. Para evitar dúvidas, esta Licença Pública não reduz, limita,
+     restringe ou impõe condições sobre qualquer utilização do
+     Material Licenciado que possa ser legalmente feita sem a
+     permissão concedida por esta Licença Pública, e não deve ser
+     interpretada nesse sentido.
+
+  b. Na medida do possível, se alguma disposição desta Licença Pública
+     for considerada inexequível, será automaticamente reformada na
+     medida estritamente necessária para que se torne exequível. Se a
+     disposição não puder ser alterada, deverá ser removida desta
+     Licença Pública sem afetar a exequibilidade dos restantes termos
+     e condições.
+
+  c. Nenhum termo ou condição desta Licença Pública será renunciado e
+     nenhuma falha no seu cumprimento consentida, salvo se tal for
+     expressamente acordado pelo Licenciante.
+
+  d. Nada nesta Licença Pública constitui ou pode ser interpretado
+     como uma limitação de, ou renúncia a, quaisquer privilégios e
+     imunidades aplicáveis ao Licenciante ou a Você, incluindo os
+     resultantes dos processos legais de qualquer jurisdição ou
+     autoridade.
+
+=======================================================================
+
+A Creative Commons não é parte das suas licenças públicas. Não
+obstante, a Creative Commons pode eleger aplicar uma das suas licenças
+públicas a material por si publicado e, nesses casos, será considerada
+um “Licenciante". O texto das licenças públicas Creative Commons é
+dedicado ao domínio público sob a CC0_Dedicação_ao_Domínio_Público.
+Exceto para o fim limitado de indicar que o material é compartilhado
+sob uma licença pública Creative Commons ou de outra forma permitida
+pelas politicas da Creative Commons publicadas em creativecommons.org/
+policies, a Creative Commons não autoriza a utilização da marca
+"Creative Commons" ou de qualquer outra marca ou logo da Creative
+Commons sem o seu prévio consentimento escrito, incluindo, mas não se
+limitando a, em conexão com qualquer modificação não autorizada de
+qualquer uma das suas licenças públicas ou de quaisquer outros pactos,
+entendimentos ou acordos relativos à utilização de material
+licenciado. Para evitar dúvidas, este parágrafo não faz parte das
+licenças públicas.
+
+Para comunicar com a Creative Commons, visite creativecommons.org.

--- a/pt/LICENSE-CC-BY-NC-SA
+++ b/pt/LICENSE-CC-BY-NC-SA
@@ -37,14 +37,15 @@ fazem parte de nossas licenças.
     identificar claramente qualquer material não sujeito à licença.
     Isso inclui outros materiais licenciados sob CC, ou materiais
     utilizados sob uma exceção ou limitação ao direito de autor e
-    direitos conexos. Mais considerações para licenciantes.
+    direitos conexos. Mais considerações para licenciantes:
+    wiki.creativecommons.org/Considerations_for_licensors.
 
     Considerações para o público: Ao utilizar uma das nossas licenças
     públicas, o licenciante concede ao público permissão para utilizar
     o material licenciado sob termos e condições especificados. Se a
     permissão do licenciante não for necessária por qualquer razão –
     por exemplo, por ser aplicável qualquer exceção ou limitação ao
-    direito de autor e direitos conexos – então essa utilização não é
+    direito de autor e direitos conexos -- então essa utilização não é
     regida pela licença. As nossas licenças concedem somente
     permissões relativas a direito de autor e direitos conexos, e
     certos outros direitos que um licenciante tenha autoridade para
@@ -54,8 +55,8 @@ fazem parte de nossas licenças.
     material. Um licenciante pode fazer pedidos especiais, como
     solicitar que todas as alterações sejam marcadas ou descritas.
     Embora não exigido pelas nossas licenças, é recomendado que você
-    respeite esses pedidos quando razoáveis.  Mais considerações para
-    o público.
+    respeite esses pedidos quando razoáveis. Mais considerações para o
+    público: wiki.creativecommons.org/Considerations_for_licensees.
 
 =======================================================================
 
@@ -202,13 +203,13 @@ Cláusula 2 -- Âmbito.
 
        5. Receptores subsequentes.
 
-            a. Oferta pelo Licenciante – Material Licenciado. Cada
+            a. Oferta pelo Licenciante -- Material Licenciado. Cada
                receptor do Material Licenciado recebe automaticamente
                uma oferta do Licenciante para exercer os Direitos
                Licenciados sob os termos e condições desta Licença
                Pública.
 
-            b. Oferta adicional pelo Licenciante – Material Adaptado.
+            b. Oferta adicional pelo Licenciante -- Material Adaptado.
                Cada receptor do Material Adaptado por Você recebe
                automaticamente uma oferta do Licenciante para exercer
                os Direitos Licenciados no Material Adaptado sob as

--- a/pt/LICENSE-CC-BY-NC-SA
+++ b/pt/LICENSE-CC-BY-NC-SA
@@ -1,0 +1,473 @@
+Atribuição-NãoComercial-CompartilhaIgual 4.0 Internacional
+
+=======================================================================
+
+A organização Creative Commons (“Creative Commons”) não é um
+escritório de advocacia e não presta serviços jurídicos ou
+aconselhamento jurídico. A distribuição das licenças públicas Creative
+Commons não estabelece uma relação advogado-cliente ou outra relação.
+A Creative Commons disponibiliza as suas licenças e informação
+relacionada “no estado em que se encontram” (“as-is”). A Creative
+Commons não oferece garantias relativamente às suas licenças, a
+qualquer material licenciado sob os seus termos e condições, ou a
+qualquer informação relacionada. A Creative Commons exonera-se, da
+forma mais ampla possível, de qualquer responsabilidade por danos
+decorrentes da sua utilização.
+
+Utilizando as Licenças Públicas Creative Commons
+
+As licenças públicas Creative Commons oferecem um conjunto padrão de
+termos e condições que criadores e outros detentores de direitos podem
+utilizar para compartilhar obras originais de autor, outros materiais
+sujeitos a direito de autor e direitos conexos, e certos outros
+direitos especificados na licença pública abaixo. As considerações a
+seguir são apenas para fins de informação, não são exaustivas e não
+fazem parte de nossas licenças.
+
+    Considerações para licenciantes: As nossas licenças públicas são
+    destinadas a utilização por aqueles que tenham autorização para
+    conceder permissão pública para a utilização de material de
+    maneiras que seriam, caso contrário, restringidas pelo direito de
+    autor e direitos conexos, e certos outros direitos. As nossas
+    licenças são irrevogáveis. Os licenciantes devem ler e entender os
+    termos e condições da licença escolhida antes de aplicá-la. Os
+    licenciantes devem assegurar todos os direitos necessários antes
+    de aplicar as nossas licenças, de modo a que o público possa
+    reutilizar o material conforme esperado. Os licenciantes devem
+    identificar claramente qualquer material não sujeito à licença.
+    Isso inclui outros materiais licenciados sob CC, ou materiais
+    utilizados sob uma exceção ou limitação ao direito de autor e
+    direitos conexos. Mais considerações para licenciantes.
+
+    Considerações para o público: Ao utilizar uma das nossas licenças
+    públicas, o licenciante concede ao público permissão para utilizar
+    o material licenciado sob termos e condições especificados. Se a
+    permissão do licenciante não for necessária por qualquer razão –
+    por exemplo, por ser aplicável qualquer exceção ou limitação ao
+    direito de autor e direitos conexos – então essa utilização não é
+    regida pela licença. As nossas licenças concedem somente
+    permissões relativas a direito de autor e direitos conexos, e
+    certos outros direitos que um licenciante tenha autoridade para
+    conceder. A utilização do material licenciado pode ainda ser
+    restringida por outras razões, incluindo porque terceiros têm
+    direito de autor e direitos conexos, ou outros direitos sobre o
+    material. Um licenciante pode fazer pedidos especiais, como
+    solicitar que todas as alterações sejam marcadas ou descritas.
+    Embora não exigido pelas nossas licenças, é recomendado que você
+    respeite esses pedidos quando razoáveis.  Mais considerações para
+    o público.
+
+=======================================================================
+
+Licença Pública Creative Commons
+Atribuição-NãoComercial-CompartilhaIgual 4.0 Internacional
+
+Ao exercer os Direitos Licenciados (definidos abaixo), Você aceita e
+concorda estar sujeito aos termos e condições desta Licença Pública
+Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0
+Internacional ("Licença Pública"). Na medida em que esta Licença
+Pública possa ser interpretada como um contrato, Você recebe os
+Direitos Licenciados em contrapartida pela Sua aceitação destes termos
+e condições, e o Licenciante concede-Lhe tais direitos em
+contrapartida pelos benefícios que o Licenciante recebe por
+disponibilizar o Material Licenciado sob estes termos e condições.
+
+Cláusula 1 -- Definições.
+
+  a. Material Adaptado significa material sujeito a Direito de Autor e
+     Direitos Similares que é derivado de ou baseado no Material
+     Licenciado e no qual o Material Licenciado é traduzido, alterado,
+     arranjado, transformado, ou de outra forma modificado de uma
+     maneira que requeira permissão com base no Direito de Autor e
+     Direitos Similares detidos pelo Licenciante. Para os fins desta
+     Licença Pública, quando o Material Licenciado seja uma obra
+     musical, performance, ou fonograma, é sempre produzido Material
+     Adaptado quando o Material Licenciado é sincronizado em relação
+     temporal com uma imagem em movimento.
+
+  b. Licença do Adaptador significa a licença que Você aplica ao Seu
+     Direito de Autor e Direitos Similares nas Suas contribuições ao
+     Material Adaptado de acordo com os termos e condições desta
+     Licença Pública.
+
+  c. Licença Compatível com a BY-NC-SA significa uma licença listada
+     em creativecommons.org/compatiblelicenses, aprovada pela Creative
+     Commons como sendo essencialmente equivalente a esta Licença
+     Pública.
+
+  d. Direito de Autor e Direitos Similares significa direito de autor
+     e/ou direitos similares estreitamente relacionados com o direito
+     de autor, incluindo, mas não se limitando a, direitos de
+     execução, radiodifusão, fixação de sons, e Direitos Sui Generis
+     sobre Bases de Dados, independentemente de como sejam
+     classificados ou categorizados. Para os fins desta Licença
+     Pública, os direitos especificados na Cláusula 2(b)(1)-(2) não
+     são Direito de Autor e Direitos Similares.
+
+  e. Medidas Eficazes de Caráter Tecnológico significam aquelas
+     medidas que, na ausência de direito para tanto, não podem ser
+     contornadas em jurisdições cumprindo obrigações sob o Artigo 11
+     do Tratado da OMPI de Direito de Autor adotado em 20 de dezembro
+     de 1996, e/ou acordos internacionais similares.
+
+  f. Exceções e Limitações significam utilização justa (“fair use”),
+     tratamento justo (“fair dealing”), e/ou qualquer outra exceção ou
+     limitação ao Direito de Autor e Direitos Similares que se aplique
+     à Sua utilização do Material Licenciado.
+
+  g. Elementos da Licença significam os atributos da licença
+     listados no nome de uma Licença Pública Creative Commons. Os
+     Elementos da Licença desta Licença Pública são Atribuição,
+     NãoComercial, e CompartilhaIgual.
+
+  h. Material Licenciado significa o trabalho artístico ou literário,
+     base de dados, ou outro material ao qual o Licenciante aplicou
+     esta Licença Pública.
+
+  i. Direitos Licenciados significam os direitos concedidos a Você
+     sujeitos aos termos e condições desta Licença Pública, que são
+     limitados a todos os Direitos de Autor e Direitos Similares que se
+     apliquem à Sua utilização do Material Licenciado e que o Licenciante
+     tem o direito de licenciar.
+
+  j. Licenciante significa o(s) indivíduo(s) ou entidade(s) concedendo
+     direitos sob esta Licença Pública.
+
+  k. NãoComercial significa não primariamente intencionado ou
+     direcionado a uma vantagem comercial ou compensação monetária.
+     Para os fins desta Licença Pública, a troca de Material
+     Licenciado por outro material sujeito a Direito de Autor e
+     Direitos Similares via compartilhamento digital de arquivos
+     ("partilha de ficheiros") ou meios similares é NãoComercial,
+     desde que não haja pagamento ou compensação monetária
+     relacionados com a troca.
+
+  l. Compartilhar significa fornecer material ao público por qualquer
+     meio ou processo que requeira permissão sob os Direitos
+     Licenciados, como reprodução, exibição pública, execução pública,
+     distribuição, disseminação, comunicação ou importação, e
+     disponibilizar material ao público, incluindo por vias pelas
+     quais os membros do público possam ter acesso ao material a
+     partir de um local e no momento individualmente escolhidos por
+     eles.
+
+  m. Direitos Sui Generis sobre Bases de Dados significam outros
+     direitos, que não o direito de autor e direitos conexos,
+     resultantes da Diretiva 96/9/EC do Parlamento Europeu e do
+     Conselho de 11 de Março de 1996 sobre a proteção legal de bases
+     de dados, conforme emendada e/ou sucedida, bem como outros
+     direitos essencialmente equivalentes em qualquer lugar do mundo.
+
+  n. Você significa o indivíduo ou entidade que exerce os Direitos
+     Licenciados sob esta Licença Pública. Lhe, Seu, Sua e Suas têm um
+     significado correspondente.
+
+
+Cláusula 2 -- Âmbito.
+
+  a. Concessão da licença.
+
+       1. De acordo com os termos e condições desta Licença Pública, o
+          Licenciante concede-Lhe, pelo presente, uma licença mundial,
+          isenta de royalties, não sublicenciável, não exclusiva, e
+          irrevogável para exercer os Direitos Licenciados sobre o
+          Material Licenciado para:
+
+           a. reproduzir e Compartilhar o Material Licenciado, no todo
+              ou em parte, somente para um fim NãoComercial; e
+
+           b. produzir, reproduzir, e Compartilhar Material Adaptado
+              somente para um fim NãoComercial.
+
+       2. Exceções e Limitações. Para evitar dúvidas, quando Exceções
+          e Limitações sejam aplicáveis à Sua utilização, esta Licença
+          Pública não se aplica, e Você não precisa de cumprir com os
+          seus termos e condições.
+
+       3. Termo. O termo desta Licença Pública está especificado na
+          Cláusula 6(a).
+
+       4. Meios/suportes e formatos; modificações técnicas permitidas.
+          O Licenciante autoriza Você a exercer os Direitos
+          Licenciados em todos os meios/suportes e formatos conhecidos
+          agora ou criados posteriormente, e a fazer as modificações
+          técnicas necessárias para tanto. O Licenciante cede e/ou
+          concorda em não reivindicar nenhum direito que proíba Você
+          de fazer modificações técnicas necessárias ao exercício dos
+          Direitos Licenciados, incluindo modificações técnicas
+          necessárias para contornar Medidas Eficazes de Caráter
+          Tecnológico. Para os fins desta Licença Pública, fazer
+          simplesmente modificações autorizadas por esta Cláusula
+          2(a)(4) nunca produz Material Adaptado.
+
+       5. Receptores subsequentes.
+
+            a. Oferta pelo Licenciante – Material Licenciado. Cada
+               receptor do Material Licenciado recebe automaticamente
+               uma oferta do Licenciante para exercer os Direitos
+               Licenciados sob os termos e condições desta Licença
+               Pública.
+
+            b. Oferta adicional pelo Licenciante – Material Adaptado.
+               Cada receptor do Material Adaptado por Você recebe
+               automaticamente uma oferta do Licenciante para exercer
+               os Direitos Licenciados no Material Adaptado sob as
+               condições da Licença do Adaptador que Você aplicar.
+
+            c. Sem restrições subsequentes. Você não pode propor ou
+               impor quaisquer termos ou condições, adicionais ou
+               diferentes, ou aplicar quaisquer Medidas Eficazes de
+               Caráter Tecnológico, sobre o Material Licenciado, se
+               tal restringir o exercício dos Direitos Licenciados por
+               qualquer receptor do Material Licenciado.
+
+       6. Sem endosso. Nada nesta Licença Pública constitui ou pode
+          ser entendido como uma permissão para afirmar ou sugerir que
+          Você, ou que a Sua utilização do Material Licenciado, é
+          conectado ao, patrocinado ou endossado pelo, ou tem status
+          oficial concedido pelo, Licenciante ou terceiros designados
+          para receber atribuição como previsto na Cláusula
+          3(a)(1)(A)(i).
+
+  b. Outros direitos.
+
+       1. Direitos morais, como o direito à integridade, não são
+          licenciados por esta Licença Pública, nem o são os direitos
+          de imagem, privacidade, e/ou outros direitos de
+          personalidade similares; contudo, na medida do possível, o
+          Licenciante renuncia e/ou concorda não exercer quaisquer
+          desses direitos detidos pelo Licenciante, na medida
+          necessária para permitir que Você exerça os Direitos
+          Licenciados, mas não de outra forma.
+
+       2. Direitos de patente e marcas não se encontram licenciados
+          sob esta Licença Pública.
+
+       3. Na medida do possível, o Licenciante renuncia a qualquer
+          direito de cobrar-Lhe royalties pelo exercício dos Direitos
+          Licenciados, quer diretamente quer por meio de uma entidade
+          de gestão coletiva, sob qualquer regime de licenciamento
+          voluntário ou legal, disponível ou compulsório. Em todos os
+          outros casos, o Licenciante reserva expressamente o direito
+          de arrecadar tais royalties, inclusive quando o Material
+          Licenciado é utilizado para fins diferentes do fim
+          NãoComercial.
+
+
+Cláusula 3 -- Condições da Licença.
+
+O Seu exercício dos Direitos Licenciados fica expressamente sujeito às
+condições seguintes.
+
+  a. Atribuição.
+
+       1. Se Você Compartilhar o Material Licenciado (incluindo sob
+          uma forma modificada), Você deve:
+
+            a. manter o seguinte, se for fornecido pelo Licenciante
+               com o Material Licenciado:
+
+                 i. identificação do(s) criador(es) do Material
+                    Licenciado e quaisquer outros designados para
+                    receber atribuição, de qualquer forma razoável
+                    solicitada pelo Licenciante (incluindo por
+                    pseudónimo, se designado);
+
+                ii. um aviso de direito de autor e direitos conexos;
+
+               iii. um aviso que se refere a esta Licença Pública;
+
+                iv. um aviso que se refere à exclusão de garantias;
+
+                 v. um URI ou um hyperlink para o Material Licenciado
+                    na medida razoavelmente exequível;
+
+            b. indicar se Você modificou o Material Licenciado e
+               manter uma indicação de quaisquer modificações prévias; e
+
+            c. indicar que o Material Licenciado é licenciado com esta
+               Licença Pública, e incluir o texto de, ou o URI ou o
+               hyperlink para, esta Licença Pública.
+
+       2. Você pode satisfazer as condições da Cláusula 3(a)(1) de
+          qualquer forma razoável, tendo em conta o suporte, os meios
+          e o contexto no qual Você Compartilhar o Material
+          Licenciado. Por exemplo, pode ser razoável satisfazer as
+          condições por via do fornecimento de um URI ou de um
+          hyperlink para um recurso que inclui a informação exigida.
+
+       3. Se solicitado pelo Licenciante, Você deve remover qualquer
+          parte da informação exigida pela Cláusula 3(a)(1)(A) na
+          medida razoavelmente exequível.
+
+  b. CompartilhaIgual.
+
+     Para além das condições da Cláusula 3(a), se Você Compartilhar
+     Material Adaptado que Você produzir, as condições seguintes
+     também se aplicam.
+
+       1. A Licença do Adaptador que Você aplicar deve ser uma licença
+          Creative Commons com os mesmos Elementos da Licença, esta
+          versão ou uma posterior, ou uma Licença Compatível com a
+          BY-NC-SA.
+
+       2. Você deve incluir o texto da, ou o URI ou o hyperlink para,
+          a Licença do Adaptador que Você aplicar. Você pode
+          satisfazer esta condição de qualquer forma razoável, tendo
+          em conta o suporte, os meios e o contexto no qual Você
+          Compartilhar o Material Adaptado.
+
+       3. Você não pode propor ou impor quaisquer termos ou condições
+          adicionais ou diferentes, ou aplicar quaisquer Medidas
+          Eficazes de Caráter Tecnológico, sobre o Material Adaptado
+          que restrinjam o exercício dos direitos concedidos sob a
+          Licença do Adaptador que Você aplicar.
+
+
+Cláusula 4 -- Direitos Sui Generis sobre Bases de Dados.
+
+Quando os Direitos Licenciados incluam Direitos Sui Generis sobre
+Bases de Dados que se apliquem à Sua utilização do Material
+Licenciado:
+
+  a. para evitar dúvidas, a Cláusula 2(a)(1) concede-Lhe o direito de
+     extrair, reutilizar, reproduzir e Compartilhar a totalidade ou
+     uma parte substancial dos conteúdos da base de dados apenas para
+     fins NãoComerciais;
+
+  b. se Você incluir a totalidade ou uma parte substancial dos
+     conteúdos da base de dados numa base de dados em relação à qual
+     Você tenha Direitos Sui Generis sobre Bases de Dados, então a
+     base de dados em relação à qual Você tenha Direitos Sui Generis
+     sobre Bases de Dados (mas não os seus conteúdos individuais) é
+     Material Adaptado, incluindo para os fins da Cláusula 3(b); e
+
+  c. Você deve cumprir com as condições da Cláusula 3(a) se Você
+     Compartilhar a totalidade ou uma parte substancial dos conteúdos
+     da base de dados.
+
+Para evitar dúvidas, esta Cláusula 4 suplementa e não substitui as
+Suas obrigações sob esta Licença Pública, quando os Direitos
+Licenciados incluam outro Direito de Autor e Direitos Similares.
+
+
+Cláusula 5 -- Exclusão de Garantias e Limitação de Responsabilidade.
+
+  a. SALVO SE O LICENCIANTE FIZER SEPARADAMENTE UMA ASSUNÇÃO EM
+     SENTIDO CONTRÁRIO, NA MEDIDA DO POSSÍVEL, O LICENCIANTE
+     DISPONIBILIZA O MATERIAL LICENCIADO “NO ESTADO EM QUE SE
+     ENCONTRA” (“AS-IS”) E “COMO DISPONÍVEL” (“AS-AVAILABLE”), E NÃO
+     FAZ REPRESENTAÇÕES OU PRESTA GARANTIAS DE QUALQUER TIPO
+     RELATIVAMENTE AO MATERIAL LICENCIADO, QUER SEJAM EXPRESSAS,
+     IMPLÍCITAS, LEGAIS OU OUTRAS. ISTO INCLUI, MAS NÃO SE LIMITA A,
+     GARANTIAS QUANTO À TITULARIDADE DE DIREITOS, POTENCIAL DE
+     COMERCIALIZAÇÃO, ADEQUAÇÃO A UM FIM ESPECÍFICO, NÃO VIOLAÇÃO DE
+     DIREITOS, AUSÊNCIA DE DEFEITOS LATENTES OU OUTROS DEFEITOS,
+     EXATIDÃO, OU EXISTÊNCIA OU AUSÊNCIA DE ERROS, QUER SEJAM OU NÃO
+     CONHECIDOS OU DETETÁVEIS. QUANDO AS EXCLUSÕES DE GARANTIAS NÃO
+     SEJAM PERMITIDAS, NA ÍNTEGRA OU EM PARTE, ESTA EXCLUSÃO PODERÁ
+     NÃO APLICAR-SE A VOCÊ.
+
+  b. NA MEDIDA DO POSSÍVEL, EM NENHUM CASO SERÁ O LICENCIANTE
+     RESPONSÁVEL PARA COM VOCÊ, COM BASE EM NENHUM ARGUMENTO JURÍDICO
+     (INCLUINDO, MAS NÃO SE LIMITANDO A, NEGLIGÊNCIA) OU A OUTRO
+     TÍTULO, POR QUAISQUER PERDAS, CUSTOS, DESPESAS OU DANOS, DIRETOS,
+     ESPECIAIS, INDIRETOS, INCIDENTAIS, CONSEQUENCIAIS, PUNITIVOS,
+     EXEMPLARES OU OUTROS, RESULTANTES DESTA LICENÇA PÚBLICA OU DA
+     UTILIZAÇÃO DO MATERIAL LICENCIADO, AINDA QUE O LICENCIANTE TENHA
+     SIDO ADVERTIDO DA POSSIBILIDADE DESSAS PERDAS, CUSTOS, DESPESAS
+     OU DANOS. QUANDO A LIMITAÇÃO DE RESPONSABILIDADE NÃO SEJA
+     PERMITIDA, NA ÍNTEGRA OU EM PARTE, ESTA LIMITAÇÃO PODERÁ NÃO
+     APLICAR-SE A VOCÊ.
+
+  c. A exclusão de garantias e a limitação de responsabilidade acima
+     previstas devem ser interpretadas de uma forma que, na medida do
+     possível, mais se aproxime de uma absoluta exclusão de, e
+     renúncia a, toda e qualquer responsabilidade.
+
+
+Cláusula 6 -- Termo e Cessação.
+
+  a. Esta Licença Pública aplica-se durante o termo do Direito de
+     Autor e Direitos Similares aqui licenciados. No entanto, se Você
+     não cumprir com esta Licença Pública, então os Seus direitos sob
+     esta Licença Pública cessarão automaticamente.
+
+  b. Quando o Seu direito de utilizar o Material Licenciado tenha
+     cessado nos termos da Cláusula 6(a), será restabelecido:
+
+       1. automaticamente a partir da data em que a violação seja
+          sanada, desde que seja sanada dentro de 30 dias a contar da
+          Sua descoberta da violação; ou
+
+       2. com o expresso restabelecimento pelo Licenciante.
+
+     Para evitar dúvidas, esta Cláusula 6(b) não afeta qualquer
+     direito que o Licenciante possa ter de obter reparação e medidas
+     legais cabíveis pelas Suas violações desta Licença Pública.
+
+  c. Para evitar dúvidas, o Licenciante também poderá disponibilizar o
+     Material Licenciado sob termos ou condições separados ou parar a
+     distribuição do Material Licenciado a qualquer momento; no
+     entanto, tal não cessará esta Licença Pública.
+
+  d. As Cláusulas 1, 5, 6, 7, e 8 continuarão em vigor após a cessação
+     desta Licença Pública.
+
+
+Cláusula 7 -- Outros Termos e Condições.
+
+  a. O Licenciante não estará vinculado a quaisquer termos ou
+     condições, adicionais ou diferentes, comunicados por Você, salvo
+     se expressamente acordado.
+
+  b. Quaisquer pactos, entendimentos ou acordos relativamente ao
+     Material Licenciado não indicados aqui são separados e
+     independentes dos termos e condições desta Licença Pública.
+
+
+Section 8 -- Interpretação.
+
+  a. Para evitar dúvidas, esta Licença Pública não reduz, limita,
+     restringe ou impõe condições sobre qualquer utilização do
+     Material Licenciado que possa ser legalmente feita sem a
+     permissão concedida por esta Licença Pública, e não deve ser
+     interpretada nesse sentido.
+
+  b. Na medida do possível, se alguma disposição desta Licença Pública
+     for considerada inexequível, será automaticamente reformada na
+     medida estritamente necessária para que se torne exequível. Se a
+     disposição não puder ser alterada, deverá ser removida desta
+     Licença Pública sem afetar a exequibilidade dos restantes termos
+     e condições.
+
+  c. Nenhum termo ou condição desta Licença Pública será renunciado e
+     nenhuma falha no seu cumprimento consentida, salvo se tal for
+     expressamente acordado pelo Licenciante.
+
+  d. Nada nesta Licença Pública constitui ou pode ser interpretado
+     como uma limitação de, ou renúncia a, quaisquer privilégios e
+     imunidades aplicáveis ao Licenciante ou a Você, incluindo os
+     resultantes dos processos legais de qualquer jurisdição ou
+     autoridade.
+
+=======================================================================
+
+A Creative Commons não é parte das suas licenças públicas. Não
+obstante, a Creative Commons pode eleger aplicar uma das suas licenças
+públicas a material por si publicado e, nesses casos, será considerada
+um “Licenciante". O texto das licenças públicas Creative Commons é
+dedicado ao domínio público sob a CC0 Dedicação ao Domínio Público.
+Exceto para o fim limitado de indicar que o material é compartilhado
+sob uma licença pública Creative Commons ou de outra forma permitida
+pelas politicas da Creative Commons publicadas em
+creativecommons.org/policies, a Creative Commons não autoriza a
+utilização da marca "Creative Commons" ou de qualquer outra marca ou
+logo da Creative Commons sem o seu prévio consentimento escrito,
+incluindo, mas não se limitando a, em conexão com qualquer modificação
+não autorizada de qualquer uma das suas licenças públicas ou de
+quaisquer outros pactos, entendimentos ou acordos relativos à
+utilização de material licenciado. Para evitar dúvidas, este parágrafo
+não faz parte das licenças públicas.
+
+Para comunicar com a Creative Commons, visite creativecommons.org.

--- a/pt/LICENSE-CC-BY-SA
+++ b/pt/LICENSE-CC-BY-SA
@@ -1,0 +1,459 @@
+Atribuição-CompartilhaIgual 4.0 Internacional
+
+=======================================================================
+
+A organização Creative Commons (“Creative Commons”) não é um
+escritório de advocacia e não presta serviços jurídicos ou
+aconselhamento jurídico. A distribuição das licenças públicas Creative
+Commons não estabelece uma relação advogado-cliente ou outra relação.
+A Creative Commons disponibiliza as suas licenças e informação
+relacionada “no estado em que se encontram” (“as-is”). A Creative
+Commons não oferece garantias relativamente às suas licenças, a
+qualquer material licenciado sob os seus termos e condições, ou a
+qualquer informação relacionada. A Creative Commons exonera-se, da
+forma mais ampla possível, de qualquer responsabilidade por danos
+decorrentes da sua utilização.
+
+Utilizando as Licenças Públicas Creative Commons
+
+As licenças públicas Creative Commons oferecem um conjunto padrão de
+termos e condições que criadores e outros detentores de direitos podem
+utilizar para compartilhar obras originais de autor, outros materiais
+sujeitos a direito de autor e direitos conexos, e certos outros
+direitos especificados na licença pública abaixo. As considerações a
+seguir são apenas para fins de informação, não são exaustivas e não
+fazem parte de nossas licenças.
+
+    Considerações para licenciantes: As nossas licenças públicas são
+    destinadas a utilização por aqueles que tenham autorização para
+    conceder permissão pública para a utilização de material de
+    maneiras que seriam, caso contrário, restringidas pelo direito de
+    autor e direitos conexos, e certos outros direitos. As nossas
+    licenças são irrevogáveis. Os licenciantes devem ler e entender os
+    termos e condições da licença escolhida antes de aplicá-la. Os
+    licenciantes devem assegurar todos os direitos necessários antes
+    de aplicar as nossas licenças, de modo a que o público possa
+    reutilizar o material conforme esperado. Os licenciantes devem
+    identificar claramente qualquer material não sujeito à licença.
+    Isso inclui outros materiais licenciados sob CC, ou materiais
+    utilizados sob uma exceção ou limitação ao direito de autor e
+    direitos conexos. Mais considerações para licenciantes:
+    wiki.creativecommons.org/Considerations_for_licensors.
+
+    Considerações para o público: Ao utilizar uma das nossas licenças
+    públicas, o licenciante concede ao público permissão para utilizar
+    o material licenciado sob termos e condições especificados. Se a
+    permissão do licenciante não for necessária por qualquer razão –
+    por exemplo, por ser aplicável qualquer exceção ou limitação ao
+    direito de autor e direitos conexos -- então essa utilização não é
+    regida pela licença. As nossas licenças concedem somente
+    permissões relativas a direito de autor e direitos conexos, e
+    certos outros direitos que um licenciante tenha autoridade para
+    conceder. A utilização do material licenciado pode ainda ser
+    restringida por outras razões, incluindo porque terceiros têm
+    direito de autor e direitos conexos, ou outros direitos sobre o
+    material. Um licenciante pode fazer pedidos especiais, como
+    solicitar que todas as alterações sejam marcadas ou descritas.
+    Embora não exigido pelas nossas licenças, é recomendado que você
+    respeite esses pedidos quando razoáveis. Mais considerações para o
+    público: wiki.creativecommons.org/Considerations_for_licensees.
+
+=======================================================================
+
+Licença Pública Creative Commons Atribuição-CompartilhaIgual 4.0
+Internacional
+
+Ao exercer os Direitos Licenciados (definidos abaixo), Você aceita e
+concorda estar sujeito aos termos e condições desta Licença Pública
+Creative Commons Atribuição-CompartilhaIgual 4.0 Internacional
+("Licença Pública"). Na medida em que esta Licença Pública possa ser
+interpretada como um contrato, Você recebe os Direitos Licenciados em
+contrapartida pela Sua aceitação destes termos e condições, e o
+Licenciante concede-Lhe tais direitos em contrapartida pelos
+benefícios que o Licenciante recebe por disponibilizar o Material
+Licenciado sob estes termos e condições.
+
+Cláusula 1 -- Definições.
+
+  a. Material Adaptado significa material sujeito a Direito de Autor e
+     Direitos Similares que é derivado de ou baseado no Material
+     Licenciado e no qual o Material Licenciado é traduzido, alterado,
+     arranjado, transformado, ou de outra forma modificado de uma
+     maneira que requeira permissão com base no Direito de Autor e
+     Direitos Similares detidos pelo Licenciante. Para os fins desta
+     Licença Pública, quando o Material Licenciado seja uma obra
+     musical, performance, ou fonograma, é sempre produzido Material
+     Adaptado quando o Material Licenciado é sincronizado em relação
+     temporal com uma imagem em movimento.
+
+  b. Licença do Adaptador significa a licença que Você aplica ao Seu
+     Direito de Autor e Direitos Similares nas Suas contribuições ao
+     Material Adaptado de acordo com os termos e condições desta
+     Licença Pública.
+
+  c. Licença Compatível com a BY-SA significa uma licença listada em
+     creativecommons.org/compatiblelicenses, aprovada pela Creative
+     Commons como sendo essencialmente equivalente a esta Licença
+     Pública.
+
+  d. Direito de Autor e Direitos Similares significa direito de autor
+     e/ou direitos similares estreitamente relacionados com o direito
+     de autor, incluindo, mas não se limitando a, direitos de
+     execução, radiodifusão, fixação de sons, e Direitos Sui Generis
+     sobre Bases de Dados, independentemente de como sejam
+     classificados ou categorizados. Para os fins desta Licença
+     Pública, os direitos especificados na Cláusula 2(b)(1)-(2) não
+     são Direito de Autor e Direitos Similares.
+
+  e. Medidas Eficazes de Caráter Tecnológico significam aquelas
+     medidas que, na ausência de direito para tanto, não podem ser
+     contornadas em jurisdições cumprindo obrigações sob o Artigo 11
+     do Tratado da OMPI de Direito de Autor adotado em 20 de dezembro
+     de 1996, e/ou acordos internacionais similares.
+
+  f. Exceções e Limitações significam utilização justa (“fair use”),
+     tratamento justo (“fair dealing”), e/ou qualquer outra exceção ou
+     limitação ao Direito de Autor e Direitos Similares que se aplique
+     à Sua utilização do Material Licenciado.
+
+  g. Elementos da Licença significam os atributos da licença listados
+     no nome de uma Licença Pública Creative Commons. Os Elementos da
+     Licença desta Licença Pública são Atribuição e CompartilhaIgual.
+
+  h. Material Licenciado significa o trabalho artístico ou literário,
+     base de dados, ou outro material ao qual o Licenciante aplicou
+     esta Licença Pública.
+
+  i. Direitos Licenciados significam os direitos concedidos a Você
+     sujeitos aos termos e condições desta Licença Pública, que são
+     limitados a todos os Direitos de Autor e Direitos Similares que
+     se apliquem à Sua utilização do Material Licenciado e que o
+     Licenciante tem o direito de licenciar.
+
+  j. Licenciante significa o(s) indivíduo(s) ou entidade(s) concedendo
+     direitos sob esta Licença Pública.
+
+  k. Compartilhar significa fornecer material ao público por qualquer
+     meio ou processo que requeira permissão sob os Direitos
+     Licenciados, como reprodução, exibição pública, execução pública,
+     distribuição, disseminação, comunicação ou importação, e
+     disponibilizar material ao público, incluindo por vias pelas
+     quais os membros do público possam ter acesso ao material a
+     partir de um local e no momento individualmente escolhidos por
+     eles.
+
+  l. Direitos Sui Generis sobre Bases de Dados significam outros
+     direitos, que não o direito de autor e direitos conexos,
+     resultantes da Diretiva 96/9/EC do Parlamento Europeu e do
+     Conselho de 11 de Março de 1996 sobre a proteção legal de bases
+     de dados, conforme emendada e/ou sucedida, bem como outros
+     direitos essencialmente equivalentes em qualquer lugar do mundo.
+
+  m. Você significa o indivíduo ou entidade que exerce os Direitos
+     Licenciados sob esta Licença Pública. Lhe, Seu, Sua e Suas têm um
+     significado correspondente.
+
+Cláusula 2 -- Âmbito.
+
+  a. Concessão da licença.
+
+       1. De acordo com os termos e condições desta Licença Pública, o
+          Licenciante concede-Lhe, pelo presente, uma licença mundial,
+          isenta de royalties, não sublicenciável, não exclusiva, e
+          irrevogável para exercer os Direitos Licenciados sobre o
+          Material Licenciado para:
+
+            a. reproduzir e Compartilhar o Material Licenciado, no
+               todo ou em parte; e
+            b. produzir, reproduzir, e Compartilhar Material Adaptado.
+
+       2. Exceções e Limitações. Para evitar dúvidas, quando Exceções
+          e Limitações sejam aplicáveis à Sua utilização, esta Licença
+          Pública não se aplica, e Você não precisa de cumprir com os
+          seus termos e condições.
+
+       3. Termo. O termo desta Licença Pública está especificado na
+          Cláusula 6(a).
+
+       4. Meios/suportes e formatos; modificações técnicas permitidas.
+          O Licenciante autoriza Você a exercer os Direitos
+          Licenciados em todos os meios/suportes e formatos conhecidos
+          agora ou criados posteriormente, e a fazer as modificações
+          técnicas necessárias para tanto. O Licenciante cede e/ou
+          concorda em não reivindicar nenhum direito que proíba Você
+          de fazer modificações técnicas necessárias ao exercício dos
+          Direitos Licenciados, incluindo modificações técnicas
+          necessárias para contornar Medidas Eficazes de Caráter
+          Tecnológico. Para os fins desta Licença Pública, fazer
+          simplesmente modificações autorizadas por esta Cláusula 2(a)
+          (4) nunca produz Material Adaptado.
+
+       5. Receptores subsequentes.
+
+            a. Oferta pelo Licenciante -- Material Licenciado. Cada
+               receptor do Material Licenciado recebe automaticamente
+               uma oferta do Licenciante para exercer os Direitos
+               Licenciados sob os termos e condições desta Licença
+               Pública.
+
+            b. Oferta adicional pelo Licenciante -- Material Adaptado.
+               Cada receptor do Material Adaptado por Você recebe
+               automaticamente uma oferta do Licenciante para exercer
+               os Direitos Licenciados no Material Adaptado sob as
+               condições da Licença do Adaptador que Você aplicar.
+
+            c. Sem restrições subsequentes. Você não pode propor ou
+               impor quaisquer termos ou condições, adicionais ou
+               diferentes, ou aplicar quaisquer Medidas Eficazes de
+               Caráter Tecnológico, sobre o Material Licenciado, se
+               tal restringir o exercício dos Direitos Licenciados por
+               qualquer receptor do Material Licenciado.
+
+       6. Sem endosso. Nada nesta Licença Pública constitui ou pode
+          ser entendido como uma permissão para afirmar ou sugerir que
+          Você, ou que a Sua utilização do Material Licenciado, é
+          conectado ao, patrocinado ou endossado pelo, ou tem status
+          oficial concedido pelo, Licenciante ou terceiros designados
+          para receber atribuição como previsto na Cláusula 3(a)(1)(A)
+          (i).
+
+  b. Outros direitos.
+
+       1. Direitos morais, como o direito à integridade, não são
+          licenciados por esta Licença Pública, nem o são os direitos
+          de imagem, privacidade, e/ou outros direitos de
+          personalidade similares; contudo, na medida do possível, o
+          Licenciante renuncia e/ou concorda não exercer quaisquer
+          desses direitos detidos pelo Licenciante, na medida
+          necessária para permitir que Você exerça os Direitos
+          Licenciados, mas não de outra forma.
+
+       2. Direitos de patente e marcas não se encontram licenciados
+          sob esta Licença Pública.
+
+       3. Na medida do possível, o Licenciante renuncia a qualquer
+          direito de cobrar-Lhe royalties pelo exercício dos Direitos
+          Licenciados, quer diretamente quer por meio de uma entidade
+          de gestão coletiva, sob qualquer regime de licenciamento
+          voluntário ou legal, disponível ou compulsório. Em todos os
+          outros casos, o Licenciante reserva expressamente o direito
+          de arrecadar tais royalties.
+
+
+Cláusula 3 -- Condições da Licença.
+
+O Seu exercício dos Direitos Licenciados fica expressamente sujeito às
+condições seguintes.
+
+  a. Atribuição.
+
+       1. Se Você Compartilhar o Material Licenciado (incluindo sob
+          uma forma modificada), Você deve:
+
+            a. manter o seguinte, se for fornecido pelo Licenciante
+               com o Material Licenciado:
+
+                 i. identificação do(s) criador(es) do Material
+                    Licenciado e quaisquer outros designados para
+                    receber atribuição, de qualquer forma razoável
+                    solicitada pelo Licenciante (incluindo por
+                    pseudónimo, se designado);
+
+                ii. um aviso de direito de autor e direitos conexos;
+
+               iii. um aviso que se refere a esta Licença Pública;
+
+                iv. um aviso que se refere à exclusão de garantias;
+
+                 v. um URI ou um hyperlink para o Material Licenciado
+                    na medida razoavelmente exequível;
+
+            b. indicar se Você modificou o Material Licenciado e
+               manter uma indicação de quaisquer modificações prévias;
+               e
+
+            c. indicar que o Material Licenciado é licenciado com esta
+               Licença Pública, e incluir o texto de, ou o URI ou o
+               hyperlink para, esta Licença Pública.
+
+       2. Você pode satisfazer as condições da Cláusula 3(a)(1) de
+          qualquer forma razoável, tendo em conta o suporte, os meios
+          e o contexto no qual Você Compartilhar o Material
+          Licenciado. Por exemplo, pode ser razoável satisfazer as
+          condições por via do fornecimento de um URI ou de um
+          hyperlink para um recurso que inclui a informação exigida.
+
+       3. Se solicitado pelo Licenciante, Você deve remover qualquer
+          parte da informação exigida pela Cláusula 3(a)(1)(A) na
+          medida razoavelmente exequível.
+
+  b. CompartilhaIgual.
+
+     Para além das condições da Cláusula 3(a), se Você Compartilhar
+     Material Adaptado que Você produzir, as condições seguintes
+     também se aplicam.
+
+       1. A Licença do Adaptador que Você aplicar deve ser uma licença
+          Creative Commons com os mesmos Elementos da Licença, esta
+          versão ou uma posterior, ou uma Licença Compatível com a BY-
+          SA.
+
+       2. Você deve incluir o texto da, ou o URI ou o hyperlink para,
+          a Licença do Adaptador que Você aplicar. Você pode
+          satisfazer esta condição de qualquer forma razoável, tendo
+          em conta o suporte, os meios e o contexto no qual Você
+          Compartilhar o Material Adaptado.
+
+       3. Você não pode propor ou impor quaisquer termos ou condições
+          adicionais ou diferentes, ou aplicar quaisquer Medidas
+          Eficazes de Caráter Tecnológico, sobre o Material Adaptado
+          que restrinjam o exercício dos direitos concedidos sob a
+          Licença do Adaptador que Você aplicar.
+
+
+Cláusula 4 -- Direitos Sui Generis sobre Bases de Dados.
+
+Quando os Direitos Licenciados incluam Direitos Sui Generis sobre
+Bases de Dados que se apliquem à Sua utilização do Material
+Licenciado:
+
+  a. para evitar dúvidas, a Cláusula 2(a)(1) concede-Lhe o direito de
+     extrair, reutilizar, reproduzir e Compartilhar a totalidade ou
+     uma parte substancial dos conteúdos da base de dados;
+
+  b. se Você incluir a totalidade ou uma parte substancial dos
+     conteúdos da base de dados numa base de dados em relação à qual
+     Você tenha Direitos Sui Generis sobre Bases de Dados, então a
+     base de dados em relação à qual Você tenha Direitos Sui Generis
+     sobre Bases de Dados (mas não os seus conteúdos individuais) é
+     Material Adaptado, incluindo para os fins da Cláusula 3(b); e
+
+  c. Você deve cumprir com as condições da Cláusula 3(a) se Você
+     Compartilhar a totalidade ou uma parte substancial dos conteúdos
+     da base de dados.
+
+Para evitar dúvidas, esta Cláusula 4 suplementa e não substitui as
+Suas obrigações sob esta Licença Pública, quando os Direitos
+Licenciados incluam outro Direito de Autor e Direitos Similares.
+
+
+Cláusula 5 -- Exclusão de Garantias e Limitação de Responsabilidade.
+
+  a. SALVO SE O LICENCIANTE FIZER SEPARADAMENTE UMA ASSUNÇÃO EM
+     SENTIDO CONTRÁRIO, NA MEDIDA DO POSSÍVEL, O LICENCIANTE
+     DISPONIBILIZA O MATERIAL LICENCIADO “NO ESTADO EM QUE SE
+     ENCONTRA” (“AS-IS”) E “COMO DISPONÍVEL” (“AS-AVAILABLE”), E NÃO
+     FAZ REPRESENTAÇÕES OU PRESTA GARANTIAS DE QUALQUER TIPO
+     RELATIVAMENTE AO MATERIAL LICENCIADO, QUER SEJAM EXPRESSAS,
+     IMPLÍCITAS, LEGAIS OU OUTRAS. ISTO INCLUI, MAS NÃO SE LIMITA A,
+     GARANTIAS QUANTO À TITULARIDADE DE DIREITOS, POTENCIAL DE
+     COMERCIALIZAÇÃO, ADEQUAÇÃO A UM FIM ESPECÍFICO, NÃO VIOLAÇÃO DE
+     DIREITOS, AUSÊNCIA DE DEFEITOS LATENTES OU OUTROS DEFEITOS,
+     EXATIDÃO, OU EXISTÊNCIA OU AUSÊNCIA DE ERROS, QUER SEJAM OU NÃO
+     CONHECIDOS OU DETETÁVEIS. QUANDO AS EXCLUSÕES DE GARANTIAS NÃO
+     SEJAM PERMITIDAS, NA ÍNTEGRA OU EM PARTE, ESTA EXCLUSÃO PODERÁ
+     NÃO APLICAR-SE A VOCÊ.
+
+  b. NA MEDIDA DO POSSÍVEL, EM NENHUM CASO SERÁ O LICENCIANTE
+     RESPONSÁVEL PARA COM VOCÊ, COM BASE EM NENHUM ARGUMENTO JURÍDICO
+     (INCLUINDO, MAS NÃO SE LIMITANDO A, NEGLIGÊNCIA) OU A OUTRO
+     TÍTULO, POR QUAISQUER PERDAS, CUSTOS, DESPESAS OU DANOS, DIRETOS,
+     ESPECIAIS, INDIRETOS, INCIDENTAIS, CONSEQUENCIAIS, PUNITIVOS,
+     EXEMPLARES OU OUTROS, RESULTANTES DESTA LICENÇA PÚBLICA OU DA
+     UTILIZAÇÃO DO MATERIAL LICENCIADO, AINDA QUE O LICENCIANTE TENHA
+     SIDO ADVERTIDO DA POSSIBILIDADE DESSAS PERDAS, CUSTOS, DESPESAS
+     OU DANOS. QUANDO A LIMITAÇÃO DE RESPONSABILIDADE NÃO SEJA
+     PERMITIDA, NA ÍNTEGRA OU EM PARTE, ESTA LIMITAÇÃO PODERÁ NÃO
+     APLICAR-SE A VOCÊ.
+
+  c. A exclusão de garantias e a limitação de responsabilidade acima
+     previstas devem ser interpretadas de uma forma que, na medida do
+     possível, mais se aproxime de uma absoluta exclusão de, e
+     renúncia a, toda e qualquer responsabilidade.
+
+
+Cláusula 6 -- Termo e Cessação.
+
+  a. Esta Licença Pública aplica-se durante o termo do Direito de
+     Autor e Direitos Similares aqui licenciados. No entanto, se Você
+     não cumprir com esta Licença Pública, então os Seus direitos sob
+     esta Licença Pública cessarão automaticamente.
+
+  b. Quando o Seu direito de utilizar o Material Licenciado tenha
+     cessado nos termos da Cláusula 6(a), será restabelecido:
+
+       1. automaticamente a partir da data em que a violação seja
+          sanada, desde que seja sanada dentro de 30 dias a contar da
+          Sua descoberta da violação; ou
+
+       2. com o expresso restabelecimento pelo Licenciante.
+
+     Para evitar dúvidas, esta Cláusula 6(b) não afeta qualquer
+     direito que o Licenciante possa ter de obter reparação e medidas
+     legais cabíveis pelas Suas violações desta Licença Pública.
+
+  c. Para evitar dúvidas, o Licenciante também poderá disponibilizar o
+     Material Licenciado sob termos ou condições separados ou parar a
+     distribuição do Material Licenciado a qualquer momento; no
+     entanto, tal não cessará esta Licença Pública.
+
+  d. As Cláusulas 1, 5, 6, 7, e 8 continuarão em vigor após a cessação
+     desta Licença Pública.
+
+
+Cláusula 7 -- Outros Termos e Condições.
+
+  a. O Licenciante não estará vinculado a quaisquer termos ou
+     condições, adicionais ou diferentes, comunicados por Você, salvo
+     se expressamente acordado.
+
+  b. Quaisquer pactos, entendimentos ou acordos relativamente ao
+     Material Licenciado não indicados aqui são separados e
+     independentes dos termos e condições desta Licença Pública.
+
+
+Cláusula 8 -- Interpretação.
+
+  a. Para evitar dúvidas, esta Licença Pública não reduz, limita,
+     restringe ou impõe condições sobre qualquer utilização do
+     Material Licenciado que possa ser legalmente feita sem a
+     permissão concedida por esta Licença Pública, e não deve ser
+     interpretada nesse sentido.
+
+  b. Na medida do possível, se alguma disposição desta Licença Pública
+     for considerada inexequível, será automaticamente reformada na
+     medida estritamente necessária para que se torne exequível. Se a
+     disposição não puder ser alterada, deverá ser removida desta
+     Licença Pública sem afetar a exequibilidade dos restantes termos
+     e condições.
+
+  c. Nenhum termo ou condição desta Licença Pública será renunciado e
+     nenhuma falha no seu cumprimento consentida, salvo se tal for
+     expressamente acordado pelo Licenciante.
+
+  d. Nada nesta Licença Pública constitui ou pode ser interpretado
+     como uma limitação de, ou renúncia a, quaisquer privilégios e
+     imunidades aplicáveis ao Licenciante ou a Você, incluindo os
+     resultantes dos processos legais de qualquer jurisdição ou
+     autoridade.
+
+=======================================================================
+
+A Creative Commons não é parte das suas licenças públicas. Não
+obstante, a Creative Commons pode eleger aplicar uma das suas licenças
+públicas a material por si publicado e, nesses casos, será considerada
+um “Licenciante". O texto das licenças públicas Creative Commons é
+dedicado ao domínio público sob a CC0_Dedicação_ao_Domínio_Público.
+Exceto para o fim limitado de indicar que o material é compartilhado
+sob uma licença pública Creative Commons ou de outra forma permitida
+pelas politicas da Creative Commons publicadas em creativecommons.org/
+policies, a Creative Commons não autoriza a utilização da marca
+"Creative Commons" ou de qualquer outra marca ou logo da Creative
+Commons sem o seu prévio consentimento escrito, incluindo, mas não se
+limitando a, em conexão com qualquer modificação não autorizada de
+qualquer uma das suas licenças públicas ou de quaisquer outros pactos,
+entendimentos ou acordos relativos à utilização de material
+licenciado. Para evitar dúvidas, este parágrafo não faz parte das
+licenças públicas.
+
+Para comunicar com a Creative Commons, visite creativecommons.org.

--- a/pt/README.md
+++ b/pt/README.md
@@ -1,4 +1,4 @@
-# Licences Creative Commons pour GitHub Projects
+# Licenças Creative Commons para Projetos no GitHub
 
 Neste repositório, você encontrará formas simples de aplicar as licenças
 Creative Commons nos seus repositórios do GitHub em Markdown.

--- a/pt/README.md
+++ b/pt/README.md
@@ -1,0 +1,94 @@
+# Licences Creative Commons pour GitHub Projects
+
+Neste repositório, você encontrará formas simples de aplicar as licenças
+Creative Commons nos seus repositórios do GitHub em Markdown.
+
+> **ATENÇÃO :**
+> Você não deve itilizar as licenças Creative Commons para software ou código unicamente.
+> Nestes casos, prefira as licenças típicas de software ou código livre, como GPL, BSD, etc.
+> As licenças Creative Commons se aplicam unicamente à propriedade intelectual.
+
+A forma mais fácil de encontrar a licença Creative Commons que mais bem se
+aplica ao seu trabalho é o website [Creative
+Commons](https://creativecommons.org/choose/).
+
+Nós propomos uma destas três opções:
+
+* [Creative Commons Atribuição 4.0 International](#cc-atribuição-40-internacional)
+* [Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 International](#cc-atribuição---nãocomercial---compartilhaigual-40-international)
+
+Mais informações a respeito destas licenças assim como a versão em texto estão
+disponíveis no endereço https://choosealicense.com/.
+
+As versão das licenças Creative Commons em formato de imagens vetoriais estão
+disponíveis no endereço https://creativecommons.org/about/downloads/.
+
+## CC Atribuição 4.0 Internacional
+
+Para utilizar a licença CC-BY, adicione o seguinte texto ao arquivo `README.md`
+assim como o [arquivo texto](LICENSE-CC-BY) correspondente e o renomeie
+`LICENÇA`.
+
+```markdown
+Shield : [![CC BY 4.0][cc-by-shield]][cc-by]
+
+Esta obra tem a [licença Creative Commons "Atribuição" 4.0 Internacional][cc-by].
+
+[![CC BY 4.0][cc-by-image]][cc-by]
+
+[cc-by]: https://creativecommons.org/licenses/by/4.0/deed.pt_BR
+[cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
+```
+
+Shield : [![CC BY 4.0][cc-by-shield]][cc-by]
+
+Esta obra tem a [licença Creative Commons "Atribuição" 4.0 Internacional][cc-by].
+
+[![CC BY 4.0][cc-by-image]][cc-by]
+
+[cc-by]: https://creativecommons.org/licenses/by/4.0/deed.pt_BR
+[cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
+[cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
+
+
+## CC Atribuição-NãoComercial-CompartilhaIgual 4.0 International
+
+Para utilizar a licença CC-BY-NC-SA, adicione o seguinte texto ao seu arquivo
+`README.md` assim como o [arquivo texto](LICENSE-CC-BY-NC-SA) correspondente e
+o renomeie para `LICENÇA`.
+
+```markdown
+Shield : [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
+
+Esta obra tem a [licença Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 International][cc-by-nc-sa].
+
+[![CC BY-NC-SA 4.0][cc-by-nc-sa-image]][cc-by-nc-sa]
+
+[cc-by-nc-sa]: https://creativecommons.org/licenses/by-nc-sa/4.0/deed.pt_BR
+[cc-by-nc-sa-image]: https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png
+[cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg
+```
+
+Shield : [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
+
+Esta obra tem a [licença Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 International][cc-by-nc-sa].
+
+[![CC BY-NC-SA 4.0][cc-by-nc-sa-image]][cc-by-nc-sa]
+
+[cc-by-nc-sa]: https://creativecommons.org/licenses/by-nc-sa/4.0/deed.pt_BR
+[cc-by-nc-sa-image]: https://licensebuttons.net/l/by-nc-sa/4.0/88x31.png
+[cc-by-nc-sa-shield]: https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg
+
+---
+
+## Licence
+
+Shield : [![CC BY 4.0][cc-by-shield]][cc-by]
+
+Esta obra tem a [licença Creative Commons "Atribuição" 4.0 Internacional][cc-by].
+
+[![CC BY 4.0][cc-by-image]][cc-by]
+
+[cc-by]: http://creativecommons.org/licenses/by/4.0/
+[cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png

--- a/pt/README.md
+++ b/pt/README.md
@@ -1,5 +1,7 @@
 # Licenças Creative Commons para Projetos no GitHub
 
+[![Main](https://img.shields.io/badge/main%20language-EN-blue)](/../../)
+
 Neste repositório, você encontrará formas simples de aplicar as licenças
 Creative Commons nos seus repositórios do GitHub em Markdown.
 
@@ -12,9 +14,10 @@ A forma mais fácil de encontrar a licença Creative Commons que mais bem se
 aplica ao seu trabalho é o website [Creative
 Commons](https://creativecommons.org/choose/).
 
-Nós propomos uma destas três opções:
+Neste repositório, você encontra três opções:
 
 * [Creative Commons Atribuição 4.0 International](#cc-atribuição-40-internacional)
+* [Creative Commons Atribuição-CompartilhaIgual  4.0 International](#cc-atribuição-40-internacional)
 * [Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 International](#cc-atribuição---nãocomercial---compartilhaigual-40-international)
 
 Mais informações a respeito destas licenças assim como a versão em texto estão
@@ -50,6 +53,36 @@ Esta obra tem a [licença Creative Commons "Atribuição" 4.0 Internacional][cc-
 [cc-by]: https://creativecommons.org/licenses/by/4.0/deed.pt_BR
 [cc-by-image]: https://i.creativecommons.org/l/by/4.0/88x31.png
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
+
+
+## CC Atribuição-CompartilhaIgual 4.0 International
+
+Para utilizar a licença CC-BY-SA, adicione o seguinte texto ao seu arquivo
+`README.md` assim como o [arquivo texto](LICENSE-CC-BY-SA) correspondente e
+o renomeie para `LICENSE`.
+
+```markdown
+Shield : [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
+
+Esta obra tem a [licença Creative Commons Atribuição-CompartilhaIgual 4.0
+International][cc-by-sa].
+
+[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
+
+[cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/deed.fr
+[cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
+[cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
+```
+
+Shield : [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
+
+Esta obra tem a [licença Creative Commons Atribuição-CompartilhaIgual 4.0 International][cc-by-sa].
+
+[![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
+
+[cc-by-sa]: https://creativecommons.org/licenses/by-sa/4.0/deed.pt_BR
+[cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
+[cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
 
 
 ## CC Atribuição-NãoComercial-CompartilhaIgual 4.0 International

--- a/pt/README.md
+++ b/pt/README.md
@@ -16,9 +16,9 @@ Commons](https://creativecommons.org/choose/).
 
 Neste repositório, você encontra três opções:
 
-* [Creative Commons Atribuição 4.0 International](#cc-atribuição-40-internacional)
-* [Creative Commons Atribuição-CompartilhaIgual  4.0 International](#cc-atribuição-40-internacional)
-* [Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 International](#cc-atribuição---nãocomercial---compartilhaigual-40-international)
+* [Creative Commons Atribuição 4.0 Internacional](#cc-atribuição-40-internacional)
+* [Creative Commons Atribuição-CompartilhaIgual  4.0 Internacional](#cc-atribuição-40-internacional)
+* [Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 Internacional](#cc-atribuição---nãocomercial---compartilhaigual-40-internacional)
 
 Mais informações a respeito destas licenças assim como a versão em texto estão
 disponíveis no endereço https://choosealicense.com/.
@@ -30,7 +30,7 @@ disponíveis no endereço https://creativecommons.org/about/downloads/.
 
 Para utilizar a licença CC-BY, adicione o seguinte texto ao arquivo `README.md`
 assim como o [arquivo texto](LICENSE-CC-BY) correspondente e o renomeie
-`LICENÇA`.
+`LICENSE`.
 
 ```markdown
 Shield : [![CC BY 4.0][cc-by-shield]][cc-by]
@@ -55,7 +55,7 @@ Esta obra tem a [licença Creative Commons "Atribuição" 4.0 Internacional][cc-
 [cc-by-shield]: https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey.svg
 
 
-## CC Atribuição-CompartilhaIgual 4.0 International
+## CC Atribuição-CompartilhaIgual 4.0 Internacional
 
 Para utilizar a licença CC-BY-SA, adicione o seguinte texto ao seu arquivo
 `README.md` assim como o [arquivo texto](LICENSE-CC-BY-SA) correspondente e
@@ -65,7 +65,7 @@ o renomeie para `LICENSE`.
 Shield : [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
 Esta obra tem a [licença Creative Commons Atribuição-CompartilhaIgual 4.0
-International][cc-by-sa].
+Internacional][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 
@@ -76,7 +76,7 @@ International][cc-by-sa].
 
 Shield : [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]
 
-Esta obra tem a [licença Creative Commons Atribuição-CompartilhaIgual 4.0 International][cc-by-sa].
+Esta obra tem a [licença Creative Commons Atribuição-CompartilhaIgual 4.0 Internacional][cc-by-sa].
 
 [![CC BY-SA 4.0][cc-by-sa-image]][cc-by-sa]
 
@@ -85,16 +85,16 @@ Esta obra tem a [licença Creative Commons Atribuição-CompartilhaIgual 4.0 Int
 [cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
 
 
-## CC Atribuição-NãoComercial-CompartilhaIgual 4.0 International
+## CC Atribuição-NãoComercial-CompartilhaIgual 4.0 Internacional
 
 Para utilizar a licença CC-BY-NC-SA, adicione o seguinte texto ao seu arquivo
 `README.md` assim como o [arquivo texto](LICENSE-CC-BY-NC-SA) correspondente e
-o renomeie para `LICENÇA`.
+o renomeie para `LICENSE`.
 
 ```markdown
 Shield : [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
 
-Esta obra tem a [licença Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 International][cc-by-nc-sa].
+Esta obra tem a [licença Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 Internacional][cc-by-nc-sa].
 
 [![CC BY-NC-SA 4.0][cc-by-nc-sa-image]][cc-by-nc-sa]
 
@@ -105,7 +105,7 @@ Esta obra tem a [licença Creative Commons Atribuição-NãoComercial-Compartilh
 
 Shield : [![CC BY-NC-SA 4.0][cc-by-nc-sa-shield]][cc-by-nc-sa]
 
-Esta obra tem a [licença Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 International][cc-by-nc-sa].
+Esta obra tem a [licença Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 Internacional][cc-by-nc-sa].
 
 [![CC BY-NC-SA 4.0][cc-by-nc-sa-image]][cc-by-nc-sa]
 


### PR DESCRIPTION
Added the legal text in Portuguese of the CC-BY, CC-BY-SA, and CC-BY-NC-SA licenses and a README.md in conformity with the formats available in the main repo. The legal text was converted directly from the Portuguese versions available on the Creative Commons website.