### PR TITLE
Fix typos in quotes in LICENSE-CC-BY-NC

### DIFF
--- a/LICENSE-CC-BY-NC
+++ b/LICENSE-CC-BY-NC
@@ -390,7 +390,7 @@ Section 8 -- Interpretation.
 Creative Commons is not a party to its public
 licenses. Notwithstanding, Creative Commons may elect to apply one of
 its public licenses to material it publishes and in those instances
-will be considered the â€œLicensor.â€ The text of the Creative Commons
+will be considered the "Licensor." The text of the Creative Commons
 public licenses is dedicated to the public domain under the CC0 Public
 Domain Dedication. Except for the limited purpose of indicating that
 material is shared under a Creative Commons public license or as


### PR DESCRIPTION
Hi,

I found there is a typo in the LICENSE-CC-BY-NC. Now fixed.

Best,
Yipeng